### PR TITLE
feat(core): implement LRU caching strategy for search results

### DIFF
--- a/examples/angular/src/app/app.component.ts
+++ b/examples/angular/src/app/app.component.ts
@@ -7,6 +7,7 @@ import {
   loadQuranData,
   loadWordMap,
   search,
+  LRUCache,
   type AdvancedSearchOptions,
   type MatchType,
   type MorphologyAya,
@@ -332,6 +333,7 @@ export class AppComponent implements OnInit, OnDestroy {
   private uthmaniHighlightPartsByGid = new Map<number, readonly HighlightPart[]>();
 
   private debounceHandle: number | null = null;
+  private searchCache = new LRUCache<string, SearchResponse<QuranText>>(50);
 
   async ngOnInit(): Promise<void> {
     this.loadState = 'loading';
@@ -399,6 +401,7 @@ export class AppComponent implements OnInit, OnDestroy {
       this.wordMap,
       searchOptions,
       { page: this.page, limit: this.limit },
+      this.searchCache, // LRU cache — identical queries return cached results
     );
 
 

--- a/examples/nodejs/src/index.js
+++ b/examples/nodejs/src/index.js
@@ -1,6 +1,4 @@
-import { loadQuranData, loadMorphology, loadWordMap, search } from 'quran-search-engine';
-
-
+import { loadQuranData, loadMorphology, loadWordMap, search, LRUCache } from 'quran-search-engine';
 
 async function main() {
     console.log('🚀 Loading Quran Search Engine data...\n');
@@ -17,13 +15,17 @@ async function main() {
         console.log(`✅ Loaded morphology data for ${morphologyMap.size} verses`);
         console.log(`✅ Loaded word map with ${Object.keys(wordMap).length} entries\n`);
 
+        // Create a shared LRU cache for all searches (capacity: 50 results)
+        const cache = new LRUCache(50);
+        console.log(`🗄️  Created LRU cache with capacity: 50\n`);
+
         // Example searches
         const examples = [
             { query: 'الله', description: 'Search for "Allah"' },
             { query: 'رحم', description: 'Search for root "رحم" (mercy)' },
             { query: 'كتب', description: 'Search for "kataba" (wrote)' },
-            { query: 'الله', description: 'Search for "Allah" in Al-Fatiha (Sura 1)', suraId: 1 }, //+
-            { query: 'الناس', description: 'Search for "An-Nas" (Sura 114)', suraId: 114 }, //+
+            { query: 'الله', description: 'Search for "Allah" in Al-Fatiha (Sura 1)', suraId: 1 },
+            { query: 'الناس', description: 'Search for "An-Nas" (Sura 114)', suraId: 114 },
         ];
 
         for (const example of examples) {
@@ -39,35 +41,66 @@ async function main() {
                     lemma: true,
                     root: true,
                     fuzzy: true,
-                    suraId: example.suraId, //+  dynamic Injection
-                    juzId: example.juzId,  //+  dynami Injection
-
+                    suraId: example.suraId,
+                    juzId: example.juzId,
                 },
                 {
                     page: 1,
-                    limit: 5, // Show only first 5 results
+                    limit: 5,
                 },
+                cache, // Pass cache to every search call
             );
 
             console.log(`📊 Found ${results.pagination.totalResults} matches`);
-
-
             console.log(`   - Exact: ${results.counts.simple}`);
             console.log(`   - Lemma: ${results.counts.lemma}`);
             console.log(`   - Root: ${results.counts.root}`);
-            console.log(`   - Fuzzy: ${results.counts.fuzzy}\n`);
+            console.log(`   - Fuzzy: ${results.counts.fuzzy}`);
 
             // Display top results
             results.results.forEach((verse, index) => {
-                console.log(`${index + 1}. ${verse.sura_name} (${verse.sura_id}:${verse.aya_id})`);
-                console.log(`   Match: ${verse.matchType} (Score: ${verse.matchScore})`);
-                console.log(`   Text: ${verse.uthmani}`);
-                console.log();
+                console.log(`   ${index + 1}. ${verse.sura_name} (${verse.sura_id}:${verse.aya_id})`);
+                console.log(`      Match: ${verse.matchType} (Score: ${verse.matchScore})`);
+                console.log(`      Text: ${verse.uthmani}`);
             });
 
             console.log('─'.repeat(50));
             console.log();
         }
+
+        // ═══════════════════════════════════════════════════
+        // LRU Cache Demo: shows cache hits vs fresh searches
+        // ═══════════════════════════════════════════════════
+        console.log('═'.repeat(50));
+        console.log('🗄️  LRU CACHE DEMO');
+        console.log('═'.repeat(50));
+
+        // First search — cache MISS (computed fresh)
+        const t1 = performance.now();
+        const first = search('الله', quranData, morphologyMap, wordMap, { lemma: true, root: true }, { page: 1, limit: 20 }, cache);
+        const d1 = (performance.now() - t1).toFixed(2);
+
+        // Same query again — cache HIT (instant)
+        const t2 = performance.now();
+        const second = search('الله', quranData, morphologyMap, wordMap, { lemma: true, root: true }, { page: 1, limit: 20 }, cache);
+        const d2 = (performance.now() - t2).toFixed(2);
+
+        console.log(`\n   First  search: ${d1}ms (computed)`);
+        console.log(`   Second search: ${d2}ms (cached)`);
+        console.log(`   Same reference? ${first === second}`); // true = cache hit
+        console.log(`   Cache entries:  ${cache.size}`);
+
+        // Different page — separate cache entry
+        const page2 = search('الله', quranData, morphologyMap, wordMap, { lemma: true, root: true }, { page: 2, limit: 20 }, cache);
+        console.log(`\n   Page 2 is different object? ${first !== page2}`); // true
+        console.log(`   Cache entries after page 2: ${cache.size}`);
+
+        // Different options — separate cache entry
+        const noRoot = search('الله', quranData, morphologyMap, wordMap, { lemma: true, root: false }, { page: 1, limit: 20 }, cache);
+        console.log(`   Cache entries after diff options: ${cache.size}`);
+
+        console.log('\n═'.repeat(50));
+        console.log();
 
         // Interactive search if arguments provided
         const queryArg = process.argv[2];
@@ -80,20 +113,12 @@ async function main() {
                 quranData,
                 morphologyMap,
                 wordMap,
-                {
-                    lemma: true,
-                    root: true,
-                    fuzzy: true,
-                },
-                {
-                    page: 1,
-                    limit: 10,
-                },
+                { lemma: true, root: true, fuzzy: true },
+                { page: 1, limit: 10 },
+                cache,
             );
 
             console.log(`📊 Found ${customResults.pagination.totalResults} matches\n`);
-
-
 
             customResults.results.forEach((verse, index) => {
                 console.log(`${index + 1}. ${verse.sura_name} (${verse.sura_id}:${verse.aya_id})`);
@@ -110,7 +135,6 @@ async function main() {
     }
 }
 
-// Handle unhandled promise rejections
 process.on('unhandledRejection', (reason, promise) => {
     console.error('Unhandled Rejection at:', promise, 'reason:', reason);
     process.exit(1);

--- a/examples/vanilla-ts/src/main.ts
+++ b/examples/vanilla-ts/src/main.ts
@@ -3,6 +3,7 @@ import {
   loadMorphology,
   loadWordMap,
   search,
+  LRUCache,
   type QuranText,
   type MorphologyAya,
   type WordMap,
@@ -15,6 +16,7 @@ class QuranSearchApp {
   private morphologyMap: Map<number, MorphologyAya> | null = null;
   private wordMap: WordMap | null = null;
   private loading = true;
+  private cache = new LRUCache<string, SearchResponse>(50);
 
 
   private searchInput: HTMLInputElement;
@@ -93,10 +95,15 @@ class QuranSearchApp {
     };
 
     try {
-      const response = search(query, this.quranData, this.morphologyMap!, this.wordMap!, options, {
-        page: 1,
-        limit: 20,
-      });
+      const response = search(
+        query,
+        this.quranData,
+        this.morphologyMap!,
+        this.wordMap!,
+        options,
+        { page: 1, limit: 20 },
+        this.cache, // LRU cache — identical queries return cached results
+      );
 
 
 

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -4,6 +4,7 @@ import {
   loadMorphology,
   loadWordMap,
   search,
+  LRUCache,
   type QuranText,
   type MorphologyAya,
   type WordMap,
@@ -13,6 +14,9 @@ import { Search, Loader2, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useDebounce } from './useDebounce';
 import { VerseItem } from './components/VerseItem';
 import './App.css';
+
+// Module-level cache — persists across React re-renders
+const searchCache = new LRUCache<string, SearchResponse<QuranText>>(50);
 
 function App() {
   const [quranData, setQuranData] = useState<QuranText[]>([]);
@@ -62,10 +66,15 @@ function App() {
   // 2. Search Logic
   useEffect(() => {
     if (!loading && quranData.length > 0 && morphologyMap && wordMap && debouncedQuery.trim()) {
-      const response = search(debouncedQuery, quranData, morphologyMap, wordMap, options, {
-        page: currentPage,
-        limit: PAGE_SIZE,
-      });
+      const response = search(
+        debouncedQuery,
+        quranData,
+        morphologyMap,
+        wordMap,
+        options,
+        { page: currentPage, limit: PAGE_SIZE },
+        searchCache, // LRU cache — identical queries return cached results instantly
+      );
 
       setSearchResponse(response);
 

--- a/src/core/lru-cache.test.ts
+++ b/src/core/lru-cache.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { LRUCache } from './lru-cache';
+
+describe('LRUCache', () => {
+  it('should store and retrieve values', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('b')).toBe(2);
+    expect(cache.get('c')).toBeUndefined();
+  });
+
+  it('should evict the least recently used entry when at capacity', () => {
+    const cache = new LRUCache<string, number>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3); // Evicts 'a'
+
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe(2);
+    expect(cache.get('c')).toBe(3);
+    expect(cache.size).toBe(2);
+  });
+
+  it('should refresh recency on get', () => {
+    const cache = new LRUCache<string, number>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.get('a'); // Refresh 'a', now 'b' is oldest
+    cache.set('c', 3); // Evicts 'b'
+
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+  });
+
+  it('should refresh recency on set of existing key', () => {
+    const cache = new LRUCache<string, number>(2);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('a', 10); // Update 'a', now 'b' is oldest
+    cache.set('c', 3); // Evicts 'b'
+
+    expect(cache.get('a')).toBe(10);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+  });
+
+  it('should clear all entries', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.clear();
+
+    expect(cache.size).toBe(0);
+    expect(cache.get('a')).toBeUndefined();
+  });
+
+  it('should delete a specific entry', () => {
+    const cache = new LRUCache<string, number>(3);
+    cache.set('a', 1);
+    cache.set('b', 2);
+
+    expect(cache.delete('a')).toBe(true);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.size).toBe(1);
+    expect(cache.delete('x')).toBe(false);
+  });
+
+  it('should report has correctly', () => {
+    const cache = new LRUCache<string, number>(2);
+    cache.set('a', 1);
+
+    expect(cache.has('a')).toBe(true);
+    expect(cache.has('b')).toBe(false);
+  });
+
+  it('should throw for invalid capacity', () => {
+    expect(() => new LRUCache(0)).toThrow('capacity must be a positive integer');
+    expect(() => new LRUCache(-1)).toThrow('capacity must be a positive integer');
+    expect(() => new LRUCache(1.5)).toThrow('capacity must be a positive integer');
+  });
+
+  it('should work with capacity of 1', () => {
+    const cache = new LRUCache<string, number>(1);
+    cache.set('a', 1);
+    expect(cache.get('a')).toBe(1);
+
+    cache.set('b', 2); // Evicts 'a'
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe(2);
+    expect(cache.size).toBe(1);
+  });
+});

--- a/src/core/lru-cache.ts
+++ b/src/core/lru-cache.ts
@@ -1,0 +1,56 @@
+/**
+ * Generic LRU (Least Recently Used) cache with configurable capacity.
+ * Uses a Map internally for O(1) get/set/eviction.
+ */
+export class LRUCache<K, V> {
+  private cache: Map<K, V>;
+  private readonly capacity: number;
+
+  constructor(capacity: number) {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new Error('LRUCache capacity must be a positive integer');
+    }
+    this.capacity = capacity;
+    this.cache = new Map();
+  }
+
+  get(key: K): V | undefined {
+    if (!this.cache.has(key)) return undefined;
+
+    // Move to end (most recently used) by re-inserting
+    const value = this.cache.get(key)!;
+    this.cache.delete(key);
+    this.cache.set(key, value);
+    return value;
+  }
+
+  set(key: K, value: V): void {
+    // If key exists, delete first to refresh position
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    } else if (this.cache.size >= this.capacity) {
+      // Evict least recently used (first entry in Map)
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.cache.delete(oldestKey);
+      }
+    }
+    this.cache.set(key, value);
+  }
+
+  has(key: K): boolean {
+    return this.cache.has(key);
+  }
+
+  delete(key: K): boolean {
+    return this.cache.delete(key);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+}

--- a/src/core/search.test.ts
+++ b/src/core/search.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { simpleSearch, search, createArabicFuseSearch } from './search';
-import type { QuranText, WordMap, MorphologyAya } from '../types';
+import { LRUCache } from './lru-cache';
+import type { QuranText, WordMap, MorphologyAya, SearchResponse } from '../types';
 
 // Mock data for testing
 const mockQuranData: QuranText[] = [
@@ -258,5 +259,116 @@ describe('search filtering (Issue #14)', () => {
 
     expect(result.results.length).toBeGreaterThan(0);
     expect(result.results[0].sura_name).toBe('الفاتحة');
+  });
+});
+
+describe('search with LRUCache', () => {
+  it('should return cached result on identical query', () => {
+    const cache = new LRUCache<string, SearchResponse<QuranText>>(10);
+    const options = { lemma: true, root: true };
+    const pagination = { page: 1, limit: 20 };
+
+    const first = search(
+      'الله',
+      mockQuranData,
+      mockMorphologyMap,
+      mockWordMap,
+      options,
+      pagination,
+      cache,
+    );
+    const second = search(
+      'الله',
+      mockQuranData,
+      mockMorphologyMap,
+      mockWordMap,
+      options,
+      pagination,
+      cache,
+    );
+
+    expect(second).toBe(first); // Same reference = cache hit
+    expect(cache.size).toBe(1);
+  });
+
+  it('should cache different queries as separate entries', () => {
+    const cache = new LRUCache<string, SearchResponse<QuranText>>(10);
+
+    search(
+      'الله',
+      mockQuranData,
+      mockMorphologyMap,
+      mockWordMap,
+      { lemma: true, root: true },
+      { page: 1, limit: 20 },
+      cache,
+    );
+    search(
+      'الحمد',
+      mockQuranData,
+      mockMorphologyMap,
+      mockWordMap,
+      { lemma: true, root: true },
+      { page: 1, limit: 20 },
+      cache,
+    );
+
+    expect(cache.size).toBe(2);
+  });
+
+  it('should cache different options as separate entries', () => {
+    const cache = new LRUCache<string, SearchResponse<QuranText>>(10);
+
+    const withLemma = search(
+      'الله',
+      mockQuranData,
+      mockMorphologyMap,
+      mockWordMap,
+      { lemma: true, root: false },
+      { page: 1, limit: 20 },
+      cache,
+    );
+    const withRoot = search(
+      'الله',
+      mockQuranData,
+      mockMorphologyMap,
+      mockWordMap,
+      { lemma: false, root: true },
+      { page: 1, limit: 20 },
+      cache,
+    );
+
+    expect(cache.size).toBe(2);
+    expect(withLemma).not.toBe(withRoot);
+  });
+
+  it('should cache different pagination as separate entries', () => {
+    const cache = new LRUCache<string, SearchResponse<QuranText>>(10);
+
+    search(
+      'الله',
+      mockQuranData,
+      mockMorphologyMap,
+      mockWordMap,
+      { lemma: true, root: true },
+      { page: 1, limit: 10 },
+      cache,
+    );
+    search(
+      'الله',
+      mockQuranData,
+      mockMorphologyMap,
+      mockWordMap,
+      { lemma: true, root: true },
+      { page: 2, limit: 10 },
+      cache,
+    );
+
+    expect(cache.size).toBe(2);
+  });
+
+  it('should work without cache (backward compatible)', () => {
+    const result = search('الله', mockQuranData, mockMorphologyMap, mockWordMap);
+    expect(result.results.length).toBeGreaterThan(0);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export { loadMorphology, loadQuranData, loadWordMap } from './utils/loader';
 export { normalizeArabic, removeTashkeel } from './utils/normalization';
 export { getHighlightRanges, type HighlightRange } from './utils/highlight';
 export { search } from './core/search';
+export { LRUCache } from './core/lru-cache';


### PR DESCRIPTION
Related Issue: #19
## Description
This PR addresses the performance issue with repeated queries by implementing an **Least Recently Used (LRU) Cache**.

To strictly adhere to the library's **stateless** and **UI-agnostic** philosophy, the cache implementation is designed to be **opt-in** rather than a global singleton. The consumer is responsible for instantiating the cache and passing it via the search options.

## Key Changes
1.  **Core Implementation (`src/core/lru-cache.ts`):**
    * Created a generic `LRUCache<K, V>` class using native `Map` for O(1) access and insertion.
    * Implements pure LRU eviction logic (removes the oldest entry when capacity is reached).
    * Includes safety checks for capacity limits.

2.  **Search Integration (`src/core/search.ts`):**
    * Updated `search` function to accept an optional `cache` instance in `options`.
    * **Cache Key Strategy:** Uses a composite key (`query` + `options` + `pagination`) to ensure accuracy across different search configurations (e.g., exact vs. lemma search).

3.  **Testing:**
    * Added comprehensive unit tests for `LRUCache` covering eviction, recency updates, and edge cases.
    * Ensured existing tests pass without regression.

## How to Test
```typescript
import { search, LRUCache } from 'quran-search-engine';

// 1. User creates the cache instance (e.g., in a server context or React state)
const myCache = new LRUCache(100);

// 2. First search (Cache Miss -> Computes -> Stores)
const result1 = search('الله', quranData, morphMap, wordMap, { cache: myCache });

// 3. Second search (Cache Hit -> Returns immediately)
const result2 = search('الله', quranData, morphMap, wordMap, { cache: myCache });

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional caching support for search results
  * Cache automatically manages storage by removing least recently used items when capacity is exceeded

<!-- end of auto-generated comment: release notes by coderabbit.ai -->