### PR TITLE
test: expand normalization edge case coverage

### DIFF
--- a/src/utils/normalization.test.ts
+++ b/src/utils/normalization.test.ts
@@ -5,12 +5,6 @@ describe('Normalization Utils', () => {
   describe('removeTashkeel', () => {
     it('should remove basic tashkeel', () => {
       const input = 'بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ';
-      // Expected: بسم الله الرحمن الرحيم
-      // Note: ٱ (Wasl alef) is replaced by regular alef \u0627 in removeTashkeel logic line 9?
-      // Wait, let's check the code: .replace(/\u0671/g, '\u0627')
-      // So ٱ becomes ا
-      // And tashkeel are removed.
-
       const expected = 'بسم الله الرحمن الرحيم';
       expect(removeTashkeel(input)).toBe(expected);
     });
@@ -25,10 +19,46 @@ describe('Normalization Utils', () => {
     });
 
     it('should remove various diacritics', () => {
-      // Fatha, Damma, Kasra, Sukun, Shadda, Tanween
       const input = 'فَتْحَةٌ ضَمَّةٌ كَسْرَةٌ';
       const expected = 'فتحة ضمة كسرة';
       expect(removeTashkeel(input)).toBe(expected);
+    });
+
+    it('should handle string with only spaces', () => {
+      expect(removeTashkeel('   ')).toBe('   ');
+    });
+
+    it('should handle string with only tashkeel characters', () => {
+      // All tashkeel should be removed, leaving empty string
+      const input = '\u064B\u064C\u064D\u064E\u064F\u0650\u0651\u0652';
+      expect(removeTashkeel(input)).toBe('');
+    });
+
+    it('should handle mixed Arabic and Latin characters', () => {
+      const input = 'Hello بِسْمِ World';
+      expect(removeTashkeel(input)).toBe('Hello بسم World');
+    });
+
+    it('should handle strings with numbers', () => {
+      const input = 'آية 42 مِنْ سورة البقرة';
+      expect(removeTashkeel(input)).toBe('آية 42 من سورة البقرة');
+    });
+
+    it('should handle consecutive diacritics', () => {
+      // Shadda + Fatha on same letter
+      const input = 'رَبَّنَا';
+      expect(removeTashkeel(input)).toBe('ربنا');
+    });
+
+    it('should replace Wasl alef with regular alef', () => {
+      const input = 'ٱلْحَمْدُ';
+      expect(removeTashkeel(input)).toBe('الحمد');
+    });
+
+    it('should handle Quranic annotation marks', () => {
+      // U+06D6-U+06DC range (Quranic signs)
+      const input = 'كلمة\u06D6\u06D7';
+      expect(removeTashkeel(input)).toBe('كلمة');
     });
   });
 
@@ -39,13 +69,11 @@ describe('Normalization Utils', () => {
     });
 
     it('should normalize hamza variants to standalone hamza', () => {
-      // Based on code: .replace(/[ؤئء]/g, 'ء')
       const input = 'ؤئ';
       expect(normalizeArabic(input)).toBe('ءء');
     });
 
     it('should normalize alif maqsura to ya', () => {
-      // Based on code: .replace(/ى/g, 'ي')
       const input = 'موسى';
       expect(normalizeArabic(input)).toBe('موسي');
     });
@@ -57,9 +85,80 @@ describe('Normalization Utils', () => {
 
     it('should handle complex mixed text', () => {
       const input = 'الْحَمْدُ لِلَّهِ رَبِّ الْعَالَمِينَ';
-      // removeTashkeel -> الحمد لله رب العالمين
-      // normalize -> الحمد لله رب العالمين (assuming standard alefs)
       expect(normalizeArabic(input)).toBe('الحمد لله رب العالمين');
+    });
+
+    it('should return empty string for empty input', () => {
+      expect(normalizeArabic('')).toBe('');
+    });
+
+    it('should return empty string for null-ish input', () => {
+      expect(normalizeArabic(undefined as unknown as string)).toBe('');
+      expect(normalizeArabic(null as unknown as string)).toBe('');
+    });
+
+    it('should handle string with only spaces', () => {
+      expect(normalizeArabic('   ')).toBe('');
+    });
+
+    it('should strip non-Arabic characters', () => {
+      const input = 'Hello بسم World 123';
+      expect(normalizeArabic(input)).toBe('بسم');
+    });
+
+    it('should collapse multiple spaces into single space', () => {
+      const input = 'بسم    الله    الرحمن';
+      expect(normalizeArabic(input)).toBe('بسم الله الرحمن');
+    });
+
+    it('should handle CRLF and newlines', () => {
+      const input = 'بسم\r\nالله\nالرحمن';
+      expect(normalizeArabic(input)).toBe('بسم الله الرحمن');
+    });
+
+    it('should handle strings with numbers (stripped)', () => {
+      const input = 'سورة 2 البقرة';
+      // Numbers are non-Arabic and should be stripped
+      expect(normalizeArabic(input)).toBe('سورة البقرة');
+    });
+
+    it('should handle special characters and punctuation', () => {
+      const input = 'بسم الله، الرحمن! الرحيم.';
+      expect(normalizeArabic(input)).toBe('بسم الله الرحمن الرحيم');
+    });
+
+    it('should handle text with only diacritics', () => {
+      const input = '\u064B\u064C\u064D\u064E';
+      expect(normalizeArabic(input)).toBe('');
+    });
+
+    it('should handle long text performance', () => {
+      const base = 'بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ ';
+      const longInput = base.repeat(1000);
+      const start = performance.now();
+      const result = normalizeArabic(longInput);
+      const duration = performance.now() - start;
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(duration).toBeLessThan(500); // Should complete within 500ms
+    });
+
+    it('should preserve hyphens within Arabic text', () => {
+      // Regex allows \s and - explicitly: /[^\u0621-\u064A\s-]+/g
+      const input = 'بسم-الله';
+      expect(normalizeArabic(input)).toBe('بسم-الله');
+    });
+
+    it('should handle mixed alef variants in a real word', () => {
+      // إبراهيم with hamza-below alef → ابراهيم
+      const input = 'إبراهيم';
+      expect(normalizeArabic(input)).toBe('ابراهيم');
+    });
+
+    it('should handle tah marbuta (not normalized)', () => {
+      // tah marbuta (ة) is within the Arabic range and should be preserved
+      const input = 'رحمة';
+      expect(normalizeArabic(input)).toBe('رحمة');
     });
   });
 });


### PR DESCRIPTION
## Summary
Added 20 new test cases for `removeTashkeel` and `normalizeArabic` covering edge cases that were previously missing. All 29 tests pass.

## New Test Cases

### removeTashkeel (7 new tests)
- Whitespace-only strings
- Tashkeel-only strings (all characters removed)
- Mixed Arabic/Latin text preservation
- Strings with numbers
- Consecutive diacritics (shadda + fatha on same letter)
- Wasl alef → regular alef replacement
- Quranic annotation marks (U+06D6-U+06DC range)

### normalizeArabic (13 new tests)
- Empty string returns empty
- Null/undefined inputs return empty (guard clause)
- Whitespace-only strings trimmed to empty
- Non-Arabic characters stripped
- Multiple spaces collapsed to single space
- CRLF and newline → space conversion
- Numbers stripped from mixed text
- Punctuation removal
- Diacritics-only input → empty
- Performance test: 1000x repeated Basmala (< 500ms)
- Hyphen preservation between Arabic words
- Real-world alef variants (إبراهيم → ابراهيم)
- Tah marbuta preservation (not normalized)

## Test Results
```
✓ src/utils/normalization.test.ts (29 tests) 10ms
Test Files  1 passed (1)
     Tests  29 passed (29)
```

Closes #17