### PR TITLE
add search many feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `npx quran-search-engine "<query>"` or after a global install.
 - **CLI output formats**: `--format json|csv|tsv` and `--output <file>` for scripting, alongside matching,
   scope, and pagination options that mirror the library's own defaults.
+- **Multi-term search**: `search()` now also accepts an array of terms (`search(['محمد', 'يونس'], ...)`),
+  searching each independently and merging results by `gid` with score/coverage/frequency ranking.
+  The existing string-query (AND-logic) behavior is unchanged.
 
 ## [0.3.2]
 

--- a/docs/guides/search-syntax.md
+++ b/docs/guides/search-syntax.md
@@ -83,6 +83,128 @@ clearBooleanOperators('محمد | رسول');
 
 - **Semantic Filtering:** For integrations with LLM and embeddings, boolean flags allow the engine to return `matchType: semantic` metadata gracefully.
 
+## Multi-Term Search (`search()` with an array)
+
+`search()` always applies **AND logic** for a single query string: a multi-word query like
+`'الله الرحمن'` only returns verses containing _both_ words together (see
+[AND Logic Requirements](#and-logic-requirements) above). Sometimes you want the opposite —
+search for several unrelated terms independently and see which verses matched any of them, and
+how well. For that, call `search()` with an **array of terms** instead of a single string:
+
+```typescript
+import { search } from 'quran-search-engine';
+
+const response = search(['محمد', 'يونس', 'إبراهيم'], context, {
+  lemma: true,
+  root: true,
+});
+```
+
+`search()` is overloaded: pass a `string` and you get the normal AND-logic search
+(`SearchResponse`); pass a `string[]` and you get the independent multi-term search described
+here (`MultiTermResponse`). TypeScript picks the right return type automatically based on which
+one you pass — no separate function to import.
+
+### How it works
+
+Passing an array does **not** rewrite your terms into a single `"محمد | يونس | إبراهيم"` query.
+Instead, `search()` detects the array (via `Array.isArray`) and runs its normal single-query
+pipeline once per term — independently, through the full pipeline (exact match, lemma, root,
+fuzzy, semantic) — then merges the results by verse `gid`:
+
+- A verse that matched only one term appears once, with that term's score.
+- A verse that matched multiple terms appears once, with `matchScore` and hit counts **summed**
+  across every term that matched it.
+- Repeating the same term twice in the input list (`['محمد', 'محمد']`) still counts as one
+  distinct term for coverage purposes, but its score/frequency contribution is added twice —
+  reflecting that two real searches did each find it.
+
+This matters because lemma/root/semantic matching is inherently per-term: rewriting
+`['محمد', 'يونس']` into the boolean query `'محمد | يونس'` would lose the linguistic analysis each
+individual term needs. Running `search()` separately for each term keeps that analysis intact.
+
+### Result shape
+
+Each result extends the normal `ScoredVerse` shape with three extra fields:
+
+```typescript
+type MergedSearchResult<TVerse> = ScoredVerse<TVerse> & {
+  matchedTerms: string[]; // which input terms matched this verse
+  distinctTermCount: number; // matchedTerms.length
+  totalFrequency: number; // summed hit count across all matching terms
+};
+```
+
+The overall response keeps the same `{ results, counts, pagination }` shape as `SearchResponse`
+— see [`MultiTermResponse`](../reference/api/types.md#multitermresponsetverse).
+
+### Ranking modes
+
+Pass `rankBy` in the fourth argument (alongside `page`/`limit`) to control sort order:
+
+| `rankBy`      | Sorts by                                        | Use case                                 |
+| ------------- | ----------------------------------------------- | ---------------------------------------- |
+| `'score'`     | Accumulated `matchScore` (default)              | Overall relevance                        |
+| `'coverage'`  | `distinctTermCount`, tie-broken by `matchScore` | Verses touching the most of your terms   |
+| `'frequency'` | `totalFrequency`, tie-broken by `matchScore`    | Verses with the most raw word-level hits |
+
+`matchScore` itself never changes based on `rankBy` — it's always the sum of each contributing
+term's own `search()` score. What changes is only how the merged array gets sorted:
+`'score'` uses `matchScore` as its **only** sort key, with no fallback — verses tied on
+`matchScore` keep whichever order they were first merged in. `'coverage'` and `'frequency'`
+use `matchScore` strictly as a **tiebreaker**, after their own primary metric.
+
+All three aggregate the same way — **sum across every contributing term**, not the maximum of
+any single one. `distinctTermCount` is `matchedTerms.length` (how many distinct terms hit the
+verse) and `totalFrequency` is the sum of each matching term's own hit count within that verse.
+A verse hit twice by one term and once by another (`totalFrequency: 3`) ranks the same as a verse
+hit once each by three different terms (`totalFrequency: 3`) — `'frequency'` measures total raw
+hits, not any single term's strength.
+
+```typescript
+// Verses covering the most of your terms first
+const byCoverage = search(
+  ['محمد', 'يونس', 'إبراهيم'],
+  context,
+  { lemma: true, root: true },
+  { rankBy: 'coverage', page: 1, limit: 10 },
+);
+```
+
+### Signature
+
+`search()` has two overloads — same function, dispatched by the type of `query`:
+
+```typescript
+// query: string — original single-query AND-logic search
+search(
+  query: string,
+  context: SearchContext,
+  options?: SearchOptions,
+  pagination?: { page?: number; limit?: number },
+  fuseIndex?: Fuse<TVerse>,
+  cache?: LRUCache<string, SearchResponse<TVerse>>,
+): SearchResponse
+
+// query: string[] — independent multi-term search, merged by gid
+search(
+  query: string[],
+  context: SearchContext,
+  options?: SearchOptions,
+  multiTermOptions?: {
+    page?: number;
+    limit?: number;
+    rankBy?: 'score' | 'coverage' | 'frequency';
+  },
+  fuseIndex?: Fuse<TVerse>,
+  cache?: LRUCache<string, SearchResponse<TVerse>>,
+): MultiTermResponse
+```
+
+`options`, `fuseIndex`, and `cache` are forwarded as-is to every individual per-term search, so
+anything that works with a single-string `search()` call — including `suraId`/`juzId`/`suraName`
+filters and `semantic: true` — also works per-term here.
+
 ## String Checking For Arbitrary Filters
 
 For developers requiring strict Boolean checks independent of scoring across any internal dataset.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ This library provides a deterministic and highly customizable search experience 
 - Lemma & Root matching (via morphology and word maps)
 - Regular Expression search with ReDoS safety validation
 - Advanced Fuzzy fallback
+- Independent multi-term search (`search()` with an array of terms) with score/coverage/frequency ranking
 - Computed highlight ranges (UI-agnostic)
 
 ---

--- a/docs/reference/api/types.md
+++ b/docs/reference/api/types.md
@@ -240,6 +240,68 @@ type ParsedRange = {
 
 ---
 
+## Multi-Term Search Types
+
+See the [Multi-Term Search guide](../../guides/search-syntax.md#multi-term-search-search-with-an-array) for usage.
+
+### `RankBy`
+
+Ranking strategy for `search()`'s multi-term (`string[]`) results.
+
+```typescript
+type RankBy = 'score' | 'coverage' | 'frequency';
+```
+
+### `MultiTermOptions`
+
+Pagination plus ranking mode for `search()`'s array overload. `PaginationOptions & { rankBy?: RankBy }` —
+`PaginationOptions` itself is unchanged; this only adds `rankBy` on top.
+
+```typescript
+type MultiTermOptions = {
+  /** Page number (1-based, default: 1) */
+  page?: number;
+  /** Results per page (default: 20) */
+  limit?: number;
+  /** Ranking strategy (default: 'score') */
+  rankBy?: RankBy;
+};
+```
+
+### `MergedSearchResult<TVerse>`
+
+A verse matched by one or more independent term searches, with per-verse aggregation metadata.
+
+```typescript
+type MergedSearchResult<TVerse extends VerseInput = QuranText> = ScoredVerse<TVerse> & {
+  /** Which input terms matched this verse */
+  matchedTerms: string[];
+  /** matchedTerms.length */
+  distinctTermCount: number;
+  /** Summed raw hit count across every matching term */
+  totalFrequency: number;
+};
+```
+
+### `MultiTermResponse<TVerse>`
+
+The complete result object for `search()`'s array overload. Same shape as `SearchResponse`, with `MergedSearchResult` entries.
+
+```typescript
+type MultiTermResponse<TVerse extends VerseInput = QuranText> = {
+  results: MergedSearchResult<TVerse>[];
+  counts: SearchCounts;
+  pagination: {
+    totalResults: number;
+    totalPages: number;
+    currentPage: number;
+    limit: number;
+  };
+};
+```
+
+---
+
 ## Index Types
 
 ### `LemmaIndex`, `RootIndex`, `WordIndex`
@@ -367,6 +429,7 @@ Request messages sent to the worker.
 type WorkerRequest =
   | InitDataRequest // { type: 'INIT_DATA', requestId }
   | RunSearchRequest // { type: 'RUN_SEARCH', requestId, query, options, pagination }
+  | RunSearchManyRequest // { type: 'RUN_SEARCH_MANY', requestId, terms, options, searchManyOptions }
   | DisposeRequest; // { type: 'DISPOSE' }
 ```
 
@@ -378,6 +441,7 @@ Response messages received from the worker.
 type WorkerResponse<TVerse extends VerseInput = VerseInput> =
   | InitDataResponse // { type: 'INIT_DATA_RESULT', requestId, success, error? }
   | SearchResultResponse // { type: 'SEARCH_RESULT', requestId, data, timingMs }
+  | SearchManyResultResponse // { type: 'SEARCH_MANY_RESULT', requestId, data, timingMs }
   | ErrorResponse; // { type: 'ERROR', requestId, error }
 ```
 
@@ -423,6 +487,11 @@ interface SearchWorkerClient {
     options: AdvancedSearchOptions,
     pagination: PaginationOptions,
   ): Promise<SearchResponse>;
+  runSearchMany(
+    terms: string[],
+    options: AdvancedSearchOptions,
+    searchManyOptions: MultiTermOptions,
+  ): Promise<MultiTermResponse>;
   terminate(): void;
 }
 ```

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -338,6 +338,13 @@ const result = await workerClient.runSearch(
   { page: 1, limit: 20 },
 );
 
+// Run an independent multi-term search (see the Multi-Term Search guide)
+const manyResult = await workerClient.runSearchMany(
+  ['محمد', 'يونس', 'إبراهيم'],
+  { lemma: true, root: true },
+  { page: 1, limit: 20, rankBy: 'score' },
+);
+
 // Cleanup
 workerClient.terminate();
 ```

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import {
   loadQuranData,
   loadMorphology,
@@ -15,6 +15,8 @@ import {
   type WordMap,
   type InvertedIndex,
   type SearchResponse,
+  type MultiTermResponse,
+  type RankBy,
   type SearchWorkerClient,
 } from 'quran-search-engine';
 import { Search, Loader2, ChevronLeft, ChevronRight } from 'lucide-react';
@@ -58,7 +60,19 @@ function App() {
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebounce(query, 300);
 
+  // Multi-term mode is auto-detected from the input: any 2+ whitespace-
+  // separated words dispatch to search()'s array overload (independent
+  // per-term search merged by gid); a single word goes through the normal
+  // single-query path. Memoized so `terms` keeps a stable reference across
+  // renders that don't change debouncedQuery — it's shared with the search
+  // effect below and included in that effect's own dependency array.
+  const terms = useMemo(() => debouncedQuery.split(/\s+/).filter(Boolean), [debouncedQuery]);
+  const isMultiTerm = terms.length > 1;
+  const singleQuery = terms[0] ?? debouncedQuery;
+
   const [searchResponse, setSearchResponse] = useState<SearchResponse | null>(null);
+  const [rankBy, setRankBy] = useState<RankBy>('score');
+  const [multiTermResponse, setMultiTermResponse] = useState<MultiTermResponse | null>(null);
 
   const [options, setOptions] = useState({
     lemma: true,
@@ -169,6 +183,7 @@ function App() {
   useEffect(() => {
     if (loading || !debouncedQuery.trim()) {
       setSearchResponse(null);
+      setMultiTermResponse(null);
       return;
     }
 
@@ -177,11 +192,24 @@ function App() {
     if (workerClient.current) {
       setSearching(true);
       setUsingWorker(true);
-      workerClient.current
-        .runSearch(debouncedQuery, options, { page: currentPage, limit: PAGE_SIZE })
-        .then((res) => {
-          if (!cancelled) setSearchResponse(res);
-        })
+      const request = isMultiTerm
+        ? workerClient.current
+            .runSearchMany(terms, options, { page: currentPage, limit: PAGE_SIZE, rankBy })
+            .then((res) => {
+              if (!cancelled) {
+                setMultiTermResponse(res);
+                setSearchResponse(null);
+              }
+            })
+        : workerClient.current
+            .runSearch(singleQuery, options, { page: currentPage, limit: PAGE_SIZE })
+            .then((res) => {
+              if (!cancelled) {
+                setSearchResponse(res);
+                setMultiTermResponse(null);
+              }
+            });
+      request
         .catch((err) => console.error('Worker search error:', err))
         .finally(() => {
           if (!cancelled) setSearching(false);
@@ -197,22 +225,40 @@ function App() {
     ) {
       setSearching(true);
       setUsingWorker(false);
-      const response = search(
-        debouncedQuery,
-        {
-          quranData,
-          morphologyMap,
-          wordMap,
-          semanticMap,
-          phoneticMap,
-          invertedIndex,
-        },
-        options,
-        { page: currentPage, limit: PAGE_SIZE },
-        undefined,
-        searchCache,
-      );
-      setSearchResponse(response);
+      const context = {
+        quranData,
+        morphologyMap,
+        wordMap,
+        semanticMap,
+        phoneticMap,
+        invertedIndex,
+      };
+
+      if (isMultiTerm) {
+        // Array overload — terms: string[] dispatches to the multi-term path.
+        const response = search(
+          terms,
+          context,
+          options,
+          { page: currentPage, limit: PAGE_SIZE, rankBy },
+          undefined,
+          searchCache,
+        );
+        setMultiTermResponse(response);
+        setSearchResponse(null);
+      } else {
+        // String overload — the original single-query path, unchanged.
+        const response = search(
+          singleQuery,
+          context,
+          options,
+          { page: currentPage, limit: PAGE_SIZE },
+          undefined,
+          searchCache,
+        );
+        setSearchResponse(response);
+        setMultiTermResponse(null);
+      }
       setSearching(false);
     }
 
@@ -221,8 +267,12 @@ function App() {
     };
   }, [
     debouncedQuery,
+    terms,
+    isMultiTerm,
+    singleQuery,
     options,
     currentPage,
+    rankBy,
     quranData,
     morphologyMap,
     wordMap,
@@ -235,7 +285,9 @@ function App() {
   // Reset page when query or options change
   useEffect(() => {
     setCurrentPage(1);
-  }, [debouncedQuery, options]);
+  }, [debouncedQuery, options, rankBy]);
+
+  const activeResponse = isMultiTerm ? multiTermResponse : searchResponse;
 
   if (loading) {
     return (
@@ -283,7 +335,7 @@ function App() {
         <div style={{ position: 'relative', flex: 1 }}>
           <input
             type="text"
-            placeholder="Search for a word (e.g., كتب, الله, رحم)..."
+            placeholder="Search for a word (e.g. كتب) — or several words for independent multi-term search (e.g. الله الرحمن)..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
@@ -296,6 +348,23 @@ function App() {
       </div>
 
       <div className="options-group">
+        {isMultiTerm && (
+          <label
+            className="option-item"
+            title="Multi-word input searches each term independently via search(terms: string[]) and merges results by verse gid"
+          >
+            Rank by:
+            <select
+              value={rankBy}
+              onChange={(e) => setRankBy(e.target.value as RankBy)}
+              style={{ marginLeft: '5px' }}
+            >
+              <option value="score">Score</option>
+              <option value="coverage">Coverage (distinct terms)</option>
+              <option value="frequency">Frequency (raw hits)</option>
+            </select>
+          </label>
+        )}
         <label className="option-item">
           <input
             type="checkbox"
@@ -387,55 +456,55 @@ function App() {
         </label>
       </div>
 
-      {searchResponse && (
+      {activeResponse && (
         <>
           <div className="results-info">
             <div className="results-count">
-              Found <strong>{searchResponse.pagination.totalResults}</strong> matches
-              {searchResponse.pagination.totalResults > 0 &&
-                ` (showing page ${searchResponse.pagination.currentPage} of ${searchResponse.pagination.totalPages})`}
+              Found <strong>{activeResponse.pagination.totalResults}</strong> matches
+              {activeResponse.pagination.totalResults > 0 &&
+                ` (showing page ${activeResponse.pagination.currentPage} of ${activeResponse.pagination.totalPages})`}
             </div>
             <div className="results-stats">
               <span className="stat-item">
                 <span className="indicator indicator-exact"></span>
                 <span className="stat-label">Exact:</span>
-                <span className="stat-value">{searchResponse.counts.simple}</span>
+                <span className="stat-value">{activeResponse.counts.simple}</span>
               </span>
               <span className="stat-item">
                 <span className="indicator indicator-lemma"></span>
                 <span className="stat-label">Lemma:</span>
-                <span className="stat-value">{searchResponse.counts.lemma}</span>
+                <span className="stat-value">{activeResponse.counts.lemma}</span>
               </span>
               <span className="stat-item">
                 <span className="indicator indicator-root"></span>
                 <span className="stat-label">Root:</span>
-                <span className="stat-value">{searchResponse.counts.root}</span>
+                <span className="stat-value">{activeResponse.counts.root}</span>
               </span>
               <span className="stat-item">
                 <span className="indicator indicator-fuzzy"></span>
                 <span className="stat-label">Fuzzy:</span>
-                <span className="stat-value">{searchResponse.counts.fuzzy}</span>
+                <span className="stat-value">{activeResponse.counts.fuzzy}</span>
               </span>
               <span className="stat-item">
                 <span className="indicator indicator-semantic"></span>
                 <span className="stat-label">Semantic:</span>
-                <span className="stat-value">{searchResponse.counts.semantic}</span>
+                <span className="stat-value">{activeResponse.counts.semantic}</span>
               </span>
               <span className="stat-item">
                 <span className="indicator indicator-semantic"></span>
                 <span className="stat-label">Range:</span>
-                <span className="stat-value">{searchResponse.counts.range}</span>
+                <span className="stat-value">{activeResponse.counts.range}</span>
               </span>
               <span className="stat-item">
                 <span className="indicator indicator-semantic"></span>
                 <span className="stat-label">Regex:</span>
-                <span className="stat-value">{searchResponse.counts.regex}</span>
+                <span className="stat-value">{activeResponse.counts.regex}</span>
               </span>
             </div>
           </div>
 
           <div className="results-list">
-            {searchResponse.results.map((verse) => (
+            {activeResponse.results.map((verse) => (
               <VerseItem
                 key={verse.gid}
                 verse={verse}
@@ -446,7 +515,7 @@ function App() {
             ))}
           </div>
 
-          {searchResponse.pagination.totalPages > 1 && (
+          {activeResponse.pagination.totalPages > 1 && (
             <div className="pagination-controls">
               <button
                 className="page-btn"
@@ -456,11 +525,11 @@ function App() {
                 <ChevronLeft size={20} />
               </button>
               <span>
-                Page {currentPage} of {searchResponse.pagination.totalPages}
+                Page {currentPage} of {activeResponse.pagination.totalPages}
               </span>
               <button
                 className="page-btn"
-                disabled={currentPage === searchResponse.pagination.totalPages}
+                disabled={currentPage === activeResponse.pagination.totalPages}
                 onClick={() => setCurrentPage(currentPage + 1)}
               >
                 <ChevronRight size={20} />

--- a/examples/vite-react/src/components/VerseItem.tsx
+++ b/examples/vite-react/src/components/VerseItem.tsx
@@ -1,5 +1,7 @@
 import {
   type ScoredQuranText,
+  type MergedSearchResult,
+  type QuranText,
   type MorphologyAya,
   type WordMap,
   getHighlightRanges,
@@ -7,7 +9,7 @@ import {
 import type { ReactNode } from 'react';
 
 interface VerseItemProps {
-  verse: ScoredQuranText;
+  verse: ScoredQuranText | MergedSearchResult<QuranText>;
   query: string;
   morphologyMap: Map<number, MorphologyAya>;
   wordMap: WordMap;
@@ -70,6 +72,21 @@ export function VerseItem({ verse }: VerseItemProps) {
           <span className={`match-tag tag-${verse.matchType}`}>
             {verse.matchType === 'none' ? 'fuzzy' : verse.matchType} (Score: {verse.matchScore})
           </span>
+          {'matchedTerms' in verse && (
+            <span
+              style={{
+                fontSize: '10px',
+                color: '#666',
+                background: '#eee',
+                padding: '2px 4px',
+                borderRadius: '4px',
+              }}
+              title={`Matched terms: ${verse.matchedTerms.join(', ')}`}
+            >
+              {verse.distinctTermCount} term{verse.distinctTermCount === 1 ? '' : 's'} ·{' '}
+              {verse.totalFrequency} hit{verse.totalFrequency === 1 ? '' : 's'}
+            </span>
+          )}
         </div>
       </div>
       <div className="verse-arabic">{renderHighlightedVerse()}</div>

--- a/src/core/layers/search-many.test.ts
+++ b/src/core/layers/search-many.test.ts
@@ -1,0 +1,533 @@
+import { describe, it, expect } from 'vitest';
+import { search } from '../search';
+import { mergeTermSearches } from './search-many';
+import type { QuranText, MorphologyAya, SearchContext, WordMap } from '../../types';
+
+// Four real Al-Fatihah verses, used with lemma/root/fuzzy DISABLED so only the
+// exact-substring ("text") layer is active — a verse matches a term iff one of
+// its words literally contains that term as a substring. This keeps expected
+// matches fully hand-verifiable for these merge-mechanics tests.
+const verses: QuranText[] = [
+  {
+    gid: 1,
+    uthmani: 'بِسْمِ ٱللَّهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ',
+    standard: 'بسم الله الرحمن الرحيم',
+    sura_id: 1,
+    aya_id: 1,
+    aya_id_display: '1',
+    page_id: 1,
+    juz_id: 1,
+    standard_full: 'بِسْمِ اللَّهِ الرَّحْمَنِ الرَّحِيمِ',
+    sura_name: 'الفاتحة',
+    sura_name_en: 'The Opening',
+    sura_name_romanization: 'Al-Fatihah',
+  },
+  {
+    gid: 2,
+    uthmani: 'ٱلْحَمْدُ لِلَّهِ رَبِّ ٱلْعَٰلَمِينَ',
+    standard: 'الحمد لله رب العالمين',
+    sura_id: 1,
+    aya_id: 2,
+    aya_id_display: '2',
+    page_id: 1,
+    juz_id: 1,
+    standard_full: 'الْحَمْدُ لِلَّهِ رَبِّ الْعَالَمِينَ',
+    sura_name: 'الفاتحة',
+    sura_name_en: 'The Opening',
+    sura_name_romanization: 'Al-Fatihah',
+  },
+  {
+    gid: 3,
+    uthmani: 'ٱلرَّحْمَٰنِ ٱلرَّحِيمِ',
+    standard: 'الرحمن الرحيم',
+    sura_id: 1,
+    aya_id: 3,
+    aya_id_display: '3',
+    page_id: 1,
+    juz_id: 1,
+    standard_full: 'الرَّحْمَنِ الرَّحِيمِ',
+    sura_name: 'الفاتحة',
+    sura_name_en: 'The Opening',
+    sura_name_romanization: 'Al-Fatihah',
+  },
+];
+
+const context: SearchContext<QuranText> = {
+  quranData: new Map(verses.map((v) => [v.gid, v])),
+  morphologyMap: new Map(
+    verses.map((v): [number, MorphologyAya] => [v.gid, { gid: v.gid, lemmas: [], roots: [] }]),
+  ),
+  wordMap: new Map() as WordMap,
+};
+
+// lemma/root/fuzzy off: only the exact-substring layer can contribute matches.
+const exactOnlyOptions = { lemma: false, root: false, fuzzy: false };
+
+describe('mergeTermSearches', () => {
+  it('runs a single term through searchFn and adds merge metadata, unchanged otherwise', () => {
+    const oracle = search('الله', context, exactOnlyOptions);
+    const result = mergeTermSearches(search, ['الله'], context, exactOnlyOptions);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].gid).toBe(oracle.results[0].gid);
+    expect(result[0].matchScore).toBe(oracle.results[0].matchScore);
+    expect(result[0].matchType).toBe(oracle.results[0].matchType);
+    expect(result[0].matchedTerms).toEqual(['الله']);
+    expect(result[0].distinctTermCount).toBe(1);
+    expect(result[0].totalFrequency).toBe(oracle.results[0].matchedTokens.length);
+  });
+
+  it('returns the union of independent per-term matches, not an AND-phrase intersection', () => {
+    // "الله" alone only appears in gid1; "الحمد" alone only appears in gid2.
+    // No verse contains both words, so a combined phrase search finds nothing —
+    // proving mergeTermSearches calls searchFn once per term instead of joining
+    // the terms into a single "الله الحمد" query.
+    const phraseOracle = search('الله الحمد', context, exactOnlyOptions);
+    expect(phraseOracle.results).toHaveLength(0);
+
+    const result = mergeTermSearches(search, ['الله', 'الحمد'], context, exactOnlyOptions);
+    expect(result.map((r) => r.gid).sort()).toEqual([1, 2]);
+  });
+
+  it('merges a verse matched by multiple terms, accumulating matchScore/totalFrequency', () => {
+    // "الله" matches gid1 only; "الرحمن" matches gid1 and gid3.
+    const result = mergeTermSearches(search, ['الله', 'الرحمن'], context, exactOnlyOptions);
+
+    const gid1 = result.find((r) => r.gid === 1);
+    const gid3 = result.find((r) => r.gid === 3);
+
+    expect(result).toHaveLength(2);
+    expect(gid1?.matchedTerms.sort()).toEqual(['الرحمن', 'الله']);
+    expect(gid1?.distinctTermCount).toBe(2);
+    expect(gid1?.matchScore).toBe(6); // 3 (from "الله") + 3 (from "الرحمن")
+    expect(gid1?.totalFrequency).toBe(2);
+
+    expect(gid3?.matchedTerms).toEqual(['الرحمن']);
+    expect(gid3?.distinctTermCount).toBe(1);
+    expect(gid3?.matchScore).toBe(3);
+  });
+
+  it('treats a duplicate input term as one distinct term, but still accumulates its score/frequency', () => {
+    const result = mergeTermSearches(search, ['الله', 'الله'], context, exactOnlyOptions);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].matchedTerms).toEqual(['الله']); // deduplicated, not ['الله', 'الله']
+    expect(result[0].distinctTermCount).toBe(1); // coverage does NOT double-count a repeated term
+    expect(result[0].matchScore).toBe(6); // score DOES accumulate: 3 + 3, one per searchFn call
+    expect(result[0].totalFrequency).toBe(2);
+  });
+
+  it('returns an empty array when none of the terms match anything', () => {
+    const result = mergeTermSearches(search, ['كلمةغيرموجودة'], context, exactOnlyOptions);
+    expect(result).toEqual([]);
+  });
+
+  it('does not sort or paginate — ranking is the orchestrator’s job', () => {
+    // All three terms hit disjoint verses at an equal score, so the array should
+    // come back in first-inserted order (gid1, then gid3, then gid2) rather than
+    // sorted by any ranking criterion.
+    const result = mergeTermSearches(
+      search,
+      ['الله', 'الرحمن', 'الحمد'],
+      context,
+      exactOnlyOptions,
+    );
+    expect(result.map((r) => r.gid)).toEqual([1, 3, 2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search() — the orchestrator in core/search.ts that wraps mergeTermSearches
+// with validation, rankBy sorting, pagination, and counts. Everything above this
+// point tests the layer in isolation; everything below tests what only the
+// orchestrator itself adds.
+// ---------------------------------------------------------------------------
+
+// Three synthetic verses engineered so score / coverage / frequency rankings
+// each pick a DIFFERENT verse as their top result:
+//   gid 101 - one term hits via exact+lemma+root all at once  -> score 6, coverage 1, freq 1
+//   gid 102 - two different terms each hit via root only      -> score 2, coverage 2, freq 2
+//   gid 103 - one term's substring hits three different words -> score 3, coverage 1, freq 3
+const rankingVerses: QuranText[] = [
+  {
+    gid: 101,
+    uthmani: 'الحكيم العليم',
+    standard: 'الحكيم العليم',
+    sura_id: 999,
+    aya_id: 1,
+    aya_id_display: '1',
+    page_id: 1,
+    juz_id: 1,
+    standard_full: 'الحكيم العليم',
+    sura_name: 'اختبار',
+    sura_name_en: 'Test',
+    sura_name_romanization: 'Ikhtibar',
+  },
+  {
+    gid: 102,
+    uthmani: 'رحمة قدرة',
+    standard: 'رحمة قدرة',
+    sura_id: 999,
+    aya_id: 2,
+    aya_id_display: '2',
+    page_id: 1,
+    juz_id: 1,
+    standard_full: 'رحمة قدرة',
+    sura_name: 'اختبار',
+    sura_name_en: 'Test',
+    sura_name_romanization: 'Ikhtibar',
+  },
+  {
+    gid: 103,
+    uthmani: 'نور منور نوراني',
+    standard: 'نور منور نوراني',
+    sura_id: 999,
+    aya_id: 3,
+    aya_id_display: '3',
+    page_id: 1,
+    juz_id: 1,
+    standard_full: 'نور منور نوراني',
+    sura_name: 'اختبار',
+    sura_name_en: 'Test',
+    sura_name_romanization: 'Ikhtibar',
+  },
+];
+
+const rankingContext: SearchContext<QuranText> = {
+  quranData: new Map(rankingVerses.map((v) => [v.gid, v])),
+  morphologyMap: new Map<number, MorphologyAya>([
+    [101, { gid: 101, lemmas: [], roots: [] }],
+    // roots populated so the linguistic-search candidate stage can find gid102
+    // via root lookup even though neither term appears verbatim in its text.
+    [102, { gid: 102, lemmas: [], roots: ['ر ح م', 'ق د ر'] }],
+    [103, { gid: 103, lemmas: [], roots: [] }],
+  ]),
+  wordMap: new Map(
+    Object.entries({
+      العليم: { lemma: 'علم', root: 'ع ل م' },
+      رحيم: { root: 'ر ح م' },
+      قدير: { root: 'ق د ر' },
+    }),
+  ) as WordMap,
+};
+
+const rankingTerms = ['العليم', 'رحيم', 'قدير', 'نور'];
+const rankingOptions = { lemma: true, root: true, fuzzy: false };
+
+// Two verses that TIE on totalFrequency (2) but differ in matchScore, built
+// entirely from the exact-match layer:
+//   gid201 - ONE term's substring hits two different words -> score 3, freq 2
+//   gid202 - TWO different terms each hit one word          -> score 6, freq 2
+// Used to prove 'frequency' ranking falls back to matchScore when its primary
+// metric ties. (A 'coverage' tie can't be built the same way: under exact-only
+// matching every contributing term adds a flat +3, so matchScore is always
+// exactly 3 * distinctTermCount — two verses can never tie on distinctTermCount
+// while differing in matchScore unless lemma/root scoring also contributes.)
+const tieVerses: QuranText[] = [
+  {
+    gid: 201,
+    uthmani: 'نور منور',
+    standard: 'نور منور',
+    sura_id: 999,
+    aya_id: 1,
+    aya_id_display: '1',
+    page_id: 1,
+    juz_id: 1,
+    standard_full: 'نور منور',
+    sura_name: 'اختبار',
+    sura_name_en: 'Test',
+    sura_name_romanization: 'Ikhtibar',
+  },
+  {
+    gid: 202,
+    uthmani: 'العليم الحكيم',
+    standard: 'العليم الحكيم',
+    sura_id: 999,
+    aya_id: 2,
+    aya_id_display: '2',
+    page_id: 1,
+    juz_id: 1,
+    standard_full: 'العليم الحكيم',
+    sura_name: 'اختبار',
+    sura_name_en: 'Test',
+    sura_name_romanization: 'Ikhtibar',
+  },
+];
+
+const tieContext: SearchContext<QuranText> = {
+  quranData: new Map(tieVerses.map((v) => [v.gid, v])),
+  morphologyMap: new Map(
+    tieVerses.map((v): [number, MorphologyAya] => [v.gid, { gid: v.gid, lemmas: [], roots: [] }]),
+  ),
+  wordMap: new Map() as WordMap,
+};
+
+const tieTerms = ['نور', 'العليم', 'الحكيم'];
+
+// Reuses fixture3's lemma/root/semantic morphology from search.test.ts, to
+// prove search() reuses the *full* search() pipeline unmodified.
+const pipelineContext: SearchContext<QuranText> = {
+  quranData: new Map(verses.map((v) => [v.gid, v])),
+  morphologyMap: new Map<number, MorphologyAya>([
+    [
+      1,
+      {
+        gid: 1,
+        lemmas: ['بسم', 'الله', 'الرحمن', 'الرحيم'],
+        roots: ['ب س م', 'ا ل ه', 'ر ح م', 'ر ح م'],
+      },
+    ],
+    [
+      2,
+      {
+        gid: 2,
+        lemmas: ['الحمد', 'لله', 'رب', 'العالمين'],
+        roots: ['ح م د', 'ا ل ه', 'ر ب ب', 'ع ل م'],
+      },
+    ],
+    [3, { gid: 3, lemmas: ['الرحمن', 'الرحيم'], roots: ['ر ح م', 'ر ح م'] }],
+  ]),
+  wordMap: new Map(
+    Object.entries({
+      الله: { lemma: 'الله', root: 'ا ل ه' },
+      الرحمن: { lemma: 'الرحمن', root: 'ر ح م' },
+      الحمد: { lemma: 'الحمد', root: 'ح م د' },
+    }),
+  ) as WordMap,
+};
+
+describe('search() — array overload (multi-term)', () => {
+  describe('orchestrator behavior', () => {
+    it('returns empty results when none of the terms match anything', () => {
+      const result = search(['كلمةغيرموجودة'], context, exactOnlyOptions);
+
+      expect(result.results).toEqual([]);
+      expect(result.counts.total).toBe(0);
+      expect(result.pagination).toEqual({
+        totalResults: 0,
+        totalPages: 0,
+        currentPage: 1,
+        limit: 20,
+      });
+    });
+
+    it('paginates the merged, ranked result set', () => {
+      // "الرحمن" -> gid1, gid3 | "الحمد" -> gid2 | "الدين" -> gid4 (not in this
+      // fixture, so use only the first three verses' terms). No overlaps, so
+      // all matched verses tie at matchScore 3 and are paginated one per page
+      // in the order they were first inserted into the merge map.
+      const terms = ['الرحمن', 'الحمد'];
+
+      const page1 = search(terms, context, exactOnlyOptions, { page: 1, limit: 1 });
+      const page2 = search(terms, context, exactOnlyOptions, { page: 2, limit: 1 });
+
+      expect(page1.results).toHaveLength(1);
+      expect(page2.results).toHaveLength(1);
+      expect(page1.results[0].gid).not.toBe(page2.results[0].gid);
+      expect(page1.pagination).toEqual({
+        totalResults: 3,
+        totalPages: 3,
+        currentPage: 1,
+        limit: 1,
+      });
+      expect(page2.pagination.currentPage).toBe(2);
+    });
+
+    it('computes counts from the full merged set, tallied by matchType', () => {
+      const result = search(['الله', 'الرحمن'], context, exactOnlyOptions);
+
+      expect(result.counts).toEqual({
+        simple: 2, // gid1 and gid3, both matchType 'exact'
+        lemma: 0,
+        root: 0,
+        fuzzy: 0,
+        semantic: 0,
+        regex: 0,
+        range: 0,
+        total: 2,
+      });
+    });
+  });
+
+  describe('ranking modes', () => {
+    it('rankBy "score" orders by accumulated matchScore', () => {
+      const result = search(rankingTerms, rankingContext, rankingOptions, {
+        rankBy: 'score',
+      });
+      expect(result.results[0].gid).toBe(101);
+    });
+
+    it('rankBy "coverage" orders by number of distinct matched terms', () => {
+      const result = search(rankingTerms, rankingContext, rankingOptions, {
+        rankBy: 'coverage',
+      });
+      expect(result.results[0].gid).toBe(102);
+    });
+
+    it('rankBy "frequency" orders by total raw hit count', () => {
+      const result = search(rankingTerms, rankingContext, rankingOptions, {
+        rankBy: 'frequency',
+      });
+      expect(result.results[0].gid).toBe(103);
+    });
+
+    it('defaults to "score" ranking when rankBy is omitted', () => {
+      const withDefault = search(rankingTerms, rankingContext, rankingOptions);
+      const withExplicitScore = search(rankingTerms, rankingContext, rankingOptions, {
+        rankBy: 'score',
+      });
+      expect(withDefault.results.map((r) => r.gid)).toEqual(
+        withExplicitScore.results.map((r) => r.gid),
+      );
+    });
+
+    it('rankBy "frequency" falls back to matchScore when totalFrequency ties', () => {
+      const result = search(tieTerms, tieContext, exactOnlyOptions, { rankBy: 'frequency' });
+
+      // Both verses accumulate exactly 2 hits — a genuine tie on the primary key.
+      expect(result.results.map((r) => r.totalFrequency)).toEqual([2, 2]);
+      // gid202 (matchScore 6, two exact terms) outranks gid201 (matchScore 3,
+      // one term hitting two words) purely via the matchScore tiebreak.
+      expect(result.results.map((r) => r.gid)).toEqual([202, 201]);
+      expect(result.results.map((r) => r.matchScore)).toEqual([6, 3]);
+    });
+
+    it('rankBy "score" has no secondary tiebreak — equal scores keep merge order', () => {
+      // "الرحمن" -> gid1, gid3 | "الحمد" -> gid2. No verse is matched by more
+      // than one term, so all three tie at matchScore 3. With no tiebreak,
+      // order follows first-inserted-into-the-merge-map order.
+      const terms = ['الرحمن', 'الحمد'];
+      const result = search(terms, context, exactOnlyOptions, { rankBy: 'score', limit: 10 });
+
+      expect(result.results.map((r) => r.matchScore)).toEqual([3, 3, 3]);
+      expect(result.results.map((r) => r.gid)).toEqual([1, 3, 2]);
+    });
+  });
+
+  describe('pipeline reuse (lemma/root/semantic)', () => {
+    it('reuses lemma/root matching exactly like a direct search() call', () => {
+      const options = { lemma: true, root: true };
+      const oracle = search('الرحمن', pipelineContext, options);
+      const result = search(['الرحمن'], pipelineContext, options);
+
+      expect(result.results.map((r) => r.gid).sort()).toEqual(
+        oracle.results.map((r) => r.gid).sort(),
+      );
+      for (const oracleVerse of oracle.results) {
+        const merged = result.results.find((r) => r.gid === oracleVerse.gid);
+        expect(merged?.matchScore).toBe(oracleVerse.matchScore);
+        expect(merged?.matchType).toBe(oracleVerse.matchType);
+      }
+    });
+
+    it('reuses semantic search exactly like a direct search() call', () => {
+      const options = { lemma: true, root: true, semantic: true };
+      const oracle = search('الرحمن', pipelineContext, options);
+      const result = search(['الرحمن'], pipelineContext, options);
+
+      expect(result.results.map((r) => r.gid).sort()).toEqual(
+        oracle.results.map((r) => r.gid).sort(),
+      );
+    });
+
+    it('reuses range-query shortcut per term, and tallies it correctly in counts', () => {
+      // "1:3" is a range query (aya 3 of sura 1 = gid3), taking search()'s range
+      // shortcut for that one term. It should merge like any other term's match,
+      // and — unlike the string overload's own counts, which structurally can never
+      // see a 'range' matchType — the array overload's counts must actually count it
+      // here, since it comes from one of several independent per-term search() calls.
+      const result = search(['1:3'], context, exactOnlyOptions);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].gid).toBe(3);
+      expect(result.results[0].matchType).toBe('range');
+      expect(result.results[0].matchedTerms).toEqual(['1:3']);
+      expect(result.counts).toEqual({
+        simple: 0,
+        lemma: 0,
+        root: 0,
+        fuzzy: 0,
+        semantic: 0,
+        regex: 0,
+        range: 1,
+        total: 1,
+      });
+    });
+
+    it('reuses the regex shortcut per term, and tallies it correctly in counts', () => {
+      // options.isRegex applies to every term in this call (it's one shared
+      // options object forwarded per-term), so "^الرحمن" is compiled as a regex
+      // and matched against verse.standard directly.
+      const result = search(['^الرحمن'], context, {
+        lemma: false,
+        root: false,
+        isRegex: true,
+      });
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].gid).toBe(3); // "الرحمن الرحيم" starts with "الرحمن"
+      expect(result.results[0].matchType).toBe('regex');
+      expect(result.counts).toEqual({
+        simple: 0,
+        lemma: 0,
+        root: 0,
+        fuzzy: 0,
+        semantic: 0,
+        regex: 1,
+        range: 0,
+        total: 1,
+      });
+    });
+
+    it('reuses boolean-operator parsing within a single term', () => {
+      // A single term can itself carry boolean syntax: "+الله -الرحمن" requires
+      // "الله" and excludes "الرحمن", both evaluated within that one search() call.
+      const booleanVerses: QuranText[] = [
+        {
+          gid: 301,
+          uthmani: 'اللَّهُ كَرِيمٌ',
+          standard: 'الله كريم',
+          sura_id: 999,
+          aya_id: 1,
+          aya_id_display: '1',
+          page_id: 1,
+          juz_id: 1,
+          standard_full: 'الله كريم',
+          sura_name: 'اختبار',
+          sura_name_en: 'Test',
+          sura_name_romanization: 'Ikhtibar',
+        },
+        {
+          gid: 302,
+          uthmani: 'الرَّحْمَٰنُ كَرِيمٌ',
+          standard: 'الرحمن كريم',
+          sura_id: 999,
+          aya_id: 2,
+          aya_id_display: '2',
+          page_id: 1,
+          juz_id: 1,
+          standard_full: 'الرحمن كريم',
+          sura_name: 'اختبار',
+          sura_name_en: 'Test',
+          sura_name_romanization: 'Ikhtibar',
+        },
+      ];
+      const booleanContext: SearchContext<QuranText> = {
+        quranData: new Map(booleanVerses.map((v) => [v.gid, v])),
+        morphologyMap: new Map(
+          booleanVerses.map((v): [number, MorphologyAya] => [
+            v.gid,
+            { gid: v.gid, lemmas: [], roots: [] },
+          ]),
+        ),
+        wordMap: new Map() as WordMap,
+      };
+
+      const result = search(['+الله -الرحمن'], booleanContext, exactOnlyOptions);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].gid).toBe(301); // has "الله", excludes "الرحمن"
+      expect(result.results[0].matchType).toBe('exact'); // boolean filters the set; scoring is normal
+    });
+  });
+});

--- a/src/core/layers/search-many.ts
+++ b/src/core/layers/search-many.ts
@@ -1,0 +1,170 @@
+import type Fuse from 'fuse.js';
+import type { LRUCache } from '../../utils/lru-cache';
+import { InvalidPaginationError } from '../../errors';
+import type {
+  AdvancedSearchOptions,
+  MergedSearchResult,
+  MultiTermOptions,
+  MultiTermResponse,
+  PaginationOptions,
+  SearchContext,
+  SearchCounts,
+  SearchResponse,
+  VerseInput,
+} from '../../types';
+
+/**
+ * Signature of `search()` from `core/search.ts`. Accepted as a parameter rather than
+ * imported directly, since `search.ts` imports this layer — importing `search` back
+ * here would create a circular dependency.
+ */
+export type SearchFn = <TVerse extends VerseInput>(
+  query: string,
+  context: SearchContext<TVerse>,
+  options?: AdvancedSearchOptions,
+  pagination?: PaginationOptions,
+  fuseIndex?: Fuse<TVerse>,
+  cache?: LRUCache<string, SearchResponse<TVerse>>,
+) => SearchResponse<TVerse>;
+
+/**
+ * Runs each term through `searchFn` independently (no OR-query rewriting, so
+ * lemma/root/semantic matching still operates on one term at a time) and merges
+ * the results by verse `gid`, accumulating `matchScore`/`totalFrequency` and
+ * collecting distinct matched terms. Returns an unsorted, unpaginated array —
+ * ranking and pagination are the orchestrator's job, same as every other layer.
+ * @param searchFn - The `search()` function to run each term through.
+ * @param terms - Independent search terms, e.g. ["muhammad", "yunus", "ibrahim"].
+ * @param context - The same search context accepted by `search()`.
+ * @param options - Toggles for different search modes, forwarded to each term's `search()` call.
+ * @param fuseIndex - Optional pre-built fuzzy index, forwarded to each term's `search()` call.
+ * @param cache - Optional LRU cache, forwarded to each term's `search()` call.
+ * @returns Merged results, one per distinct matched verse `gid`.
+ */
+export const mergeTermSearches = <TVerse extends VerseInput>(
+  searchFn: SearchFn,
+  terms: string[],
+  context: SearchContext<TVerse>,
+  options: AdvancedSearchOptions,
+  fuseIndex?: Fuse<TVerse>,
+  cache?: LRUCache<string, SearchResponse<TVerse>>,
+): MergedSearchResult<TVerse>[] => {
+  const merged = new Map<number, MergedSearchResult<TVerse>>();
+
+  for (const term of terms) {
+    const termResponse = searchFn(
+      term,
+      context,
+      options,
+      { page: 1, limit: Number.MAX_SAFE_INTEGER },
+      fuseIndex,
+      cache,
+    );
+
+    for (const verse of termResponse.results) {
+      const existing = merged.get(verse.gid);
+
+      if (existing) {
+        existing.matchScore += verse.matchScore;
+        existing.totalFrequency += verse.matchedTokens.length;
+        if (!existing.matchedTerms.includes(term)) {
+          existing.matchedTerms.push(term);
+          existing.distinctTermCount += 1;
+        }
+      } else {
+        merged.set(verse.gid, {
+          ...verse,
+          matchedTerms: [term],
+          distinctTermCount: 1,
+          totalFrequency: verse.matchedTokens.length,
+        });
+      }
+    }
+  }
+
+  return Array.from(merged.values());
+};
+
+/**
+ * Backs `search()`'s array (`string[]`) overload. Not exported from the package
+ * (`src/index.ts` never re-exports it) — only `core/search.ts`'s dispatcher calls
+ * it, injecting `search` itself as `searchFn` (same pattern as `mergeTermSearches`,
+ * avoiding a circular import back to `search.ts`).
+ *
+ * Merges each term's independent search via `mergeTermSearches`, then ranks,
+ * paginates, and tallies counts over the merged set.
+ * @param searchFn - The `search()` function to run each term through.
+ * @param terms - Independent search terms, e.g. ["muhammad", "yunus", "ibrahim"].
+ * @param context - The same search context accepted by `search()`.
+ * @param options - Toggles for different search modes, forwarded to each term's `search()` call.
+ * @param multiTermOptions - Pagination plus a `rankBy` mode (`score` | `coverage` | `frequency`).
+ * @param fuseIndex - Optional pre-built fuzzy index, forwarded to each term's `search()` call.
+ * @param cache - Optional LRU cache, forwarded to each term's `search()` call.
+ * @returns Paginated, merged results with metadata and match counts.
+ */
+export const searchManyImpl = <TVerse extends VerseInput>(
+  searchFn: SearchFn,
+  terms: string[],
+  context: SearchContext<TVerse>,
+  options: AdvancedSearchOptions = { lemma: true, root: true },
+  multiTermOptions: MultiTermOptions = {},
+  fuseIndex?: Fuse<TVerse>,
+  cache?: LRUCache<string, SearchResponse<TVerse>>,
+): MultiTermResponse<TVerse> => {
+  const page = multiTermOptions.page ?? 1;
+  const limit = multiTermOptions.limit ?? 20;
+  const rankBy = multiTermOptions.rankBy ?? 'score';
+
+  if (page < 1 || !Number.isInteger(page)) {
+    throw new InvalidPaginationError(page, limit);
+  }
+  if (limit < 1 || !Number.isInteger(limit)) {
+    throw new InvalidPaginationError(page, limit);
+  }
+
+  const mergedResults = mergeTermSearches(searchFn, terms, context, options, fuseIndex, cache);
+
+  // Rank by the requested strategy; ties fall back to matchScore for coverage/frequency.
+  mergedResults.sort((a, b) => {
+    switch (rankBy) {
+      case 'coverage':
+        return b.distinctTermCount - a.distinctTermCount || b.matchScore - a.matchScore;
+      case 'frequency':
+        return b.totalFrequency - a.totalFrequency || b.matchScore - a.matchScore;
+      case 'score':
+      default:
+        return b.matchScore - a.matchScore;
+    }
+  });
+
+  const offset = (page - 1) * limit;
+  const results = mergedResults.slice(offset, offset + limit);
+  const totalResults = mergedResults.length;
+  const totalPages = Math.ceil(totalResults / limit);
+
+  const counts: SearchCounts = {
+    simple: mergedResults.filter((v) => v.matchType === 'exact').length,
+    lemma: mergedResults.filter((v) => v.matchType === 'lemma').length,
+    root: mergedResults.filter((v) => v.matchType === 'root').length,
+    fuzzy: mergedResults.filter((v) => v.matchType === 'none' || v.matchType === 'fuzzy').length,
+    semantic: mergedResults.filter((v) => v.matchType === 'semantic').length,
+    // Unlike search()'s own counts (reached only after range/regex short-circuit,
+    // so those matchTypes can never appear there), mergedResults comes from N
+    // independent per-term search() calls — any one of them could have taken the
+    // range/regex early-return path, so those matchTypes genuinely can show up here.
+    regex: mergedResults.filter((v) => v.matchType === 'regex').length,
+    range: mergedResults.filter((v) => v.matchType === 'range').length,
+    total: mergedResults.length,
+  };
+
+  return {
+    results,
+    counts,
+    pagination: {
+      totalResults,
+      totalPages,
+      currentPage: page,
+      limit,
+    },
+  };
+};

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -10,6 +10,7 @@ import { filterVerses, simpleSearch, simpleSearchOr } from './layers/simple-sear
 import { createArabicFuseSearch } from './layers/fuse-search';
 import { performAdvancedLinguisticSearch } from './layers/linguistic-search';
 import { performSemanticSearch } from './layers/semantic-search';
+import { searchManyImpl } from './layers/search-many';
 import { computeScore } from '../utils/scoring';
 
 import type {
@@ -22,6 +23,8 @@ import type {
   VerseWithFuseMatches,
   BooleanQuery,
   SearchContext,
+  MultiTermOptions,
+  MultiTermResponse,
 } from '../types';
 import {
   clearBooleanOperators,
@@ -35,26 +38,59 @@ import {
  * Combines simple text search with linguistic (lemma/root) analysis and fuzzy fallback.
  * Results are scored, deduplicated, and sorted by relevance.
  * @param query - The user's input string.
- * @param quranData - The verse dataset.
- * @param morphologyMap - Morphological data for scoring.
- * @param wordMap - Dictionary for linguistic resolution.
+ * @param context - The verse dataset, morphology map, word map, and optional indexes.
  * @param options - Toggles for different search modes.
  * @param pagination - Page number and results per page.
- * @param preComputedFuseIndex - Optional pre-built fuzzy index.
+ * @param fuseIndex - Optional pre-built fuzzy index.
  * @param cache - Optional LRU cache for performance.
- * @param invertedIndex - Optional Pre-built word/lemma/root indexes.
  * @returns Paginated results with metadata and match counts.
  * @example
- * result = search("الحمد لله", quranData, morphologyMap, wordMap, options, { page: 1, limit: 10 }, undefined, searchCache)
+ * result = search("الحمد لله", context, options, { page: 1, limit: 10 }, undefined, searchCache)
  */
-export const search = <TVerse extends VerseInput>(
+export function search<TVerse extends VerseInput>(
   query: string,
   context: SearchContext<TVerse>,
-  options: AdvancedSearchOptions = { lemma: true, root: true },
-  pagination: PaginationOptions = { page: 1, limit: 20 },
+  options?: AdvancedSearchOptions,
+  pagination?: PaginationOptions,
   fuseIndex?: Fuse<TVerse>,
   cache?: LRUCache<string, SearchResponse<TVerse>>,
-): SearchResponse<TVerse> => {
+): SearchResponse<TVerse>;
+/**
+ * Searches for multiple terms independently and merges results by verse `gid`.
+ * Each term runs through the full `search()` pipeline separately (no OR-query rewriting),
+ * so lemma/root/semantic matching still operates on one term at a time as intended.
+ * @param query - Independent search terms, e.g. ["muhammad", "yunus", "ibrahim"].
+ * @param context - The same search context accepted by the string overload.
+ * @param options - Toggles for different search modes, forwarded to each term's search.
+ * @param multiTermOptions - Pagination plus a `rankBy` mode (`score` | `coverage` | `frequency`).
+ * @param fuseIndex - Optional pre-built fuzzy index, forwarded to each term's search.
+ * @param cache - Optional LRU cache, forwarded to each term's search.
+ * @returns Paginated, merged results with metadata and match counts.
+ * @example
+ * result = search(["محمد", "يونس"], context, options, { page: 1, limit: 10, rankBy: 'coverage' })
+ */
+export function search<TVerse extends VerseInput>(
+  query: string[],
+  context: SearchContext<TVerse>,
+  options?: AdvancedSearchOptions,
+  multiTermOptions?: MultiTermOptions,
+  fuseIndex?: Fuse<TVerse>,
+  cache?: LRUCache<string, SearchResponse<TVerse>>,
+): MultiTermResponse<TVerse>;
+export function search<TVerse extends VerseInput>(
+  query: string | string[],
+  context: SearchContext<TVerse>,
+  options: AdvancedSearchOptions = { lemma: true, root: true },
+  multiTermOptions: MultiTermOptions = {},
+  fuseIndex?: Fuse<TVerse>,
+  cache?: LRUCache<string, SearchResponse<TVerse>>,
+): SearchResponse<TVerse> | MultiTermResponse<TVerse> {
+  if (Array.isArray(query)) {
+    return searchManyImpl(search, query, context, options, multiTermOptions, fuseIndex, cache);
+  }
+
+  const pagination: PaginationOptions = multiTermOptions;
+
   const { quranData, morphologyMap, wordMap, invertedIndex, semanticMap, phoneticMap } = context;
 
   // Validate required dependencies
@@ -320,4 +356,4 @@ export const search = <TVerse extends VerseInput>(
   }
 
   return response;
-};
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,31 @@ export type SearchResponse<TVerse extends VerseInput = QuranText> = {
   };
 };
 
+/** Ranking strategy for search()'s multi-term (string[]) results. */
+export type RankBy = 'score' | 'coverage' | 'frequency';
+
+export type MultiTermOptions = PaginationOptions & {
+  rankBy?: RankBy;
+};
+
+/** A verse matched by one or more independent term searches, with per-verse aggregation metadata. */
+export type MergedSearchResult<TVerse extends VerseInput = QuranText> = ScoredVerse<TVerse> & {
+  matchedTerms: string[];
+  distinctTermCount: number;
+  totalFrequency: number;
+};
+
+export type MultiTermResponse<TVerse extends VerseInput = QuranText> = {
+  results: MergedSearchResult<TVerse>[];
+  counts: SearchCounts;
+  pagination: {
+    totalResults: number;
+    totalPages: number;
+    currentPage: number;
+    limit: number;
+  };
+};
+
 export type ErrorShape = {
   message: string;
   code: string;

--- a/src/worker/search-worker-client.ts
+++ b/src/worker/search-worker-client.ts
@@ -13,6 +13,8 @@ import type {
   AdvancedSearchOptions,
   PaginationOptions,
   SearchResponse,
+  MultiTermOptions,
+  MultiTermResponse,
   QuranText,
   SearchContext,
 } from '../types';
@@ -46,7 +48,9 @@ function createWorkerClient(workerUrl: URL | string): SearchWorkerClient {
     throw new WorkerInitializationError(err instanceof Error ? err.message : String(err));
   }
 
-  type PendingResolve = (value: void | SearchResponse<QuranText>) => void;
+  type PendingResolve = (
+    value: void | SearchResponse<QuranText> | MultiTermResponse<QuranText>,
+  ) => void;
   const pending = new Map<string, { resolve: PendingResolve; reject: (reason: unknown) => void }>();
 
   worker.onmessage = (event: MessageEvent<WorkerResponse<QuranText>>) => {
@@ -73,6 +77,10 @@ function createWorkerClient(workerUrl: URL | string): SearchWorkerClient {
         break;
 
       case 'SEARCH_RESULT':
+        entry.resolve(msg.data);
+        break;
+
+      case 'SEARCH_MANY_RESULT':
         entry.resolve(msg.data);
         break;
 
@@ -117,6 +125,21 @@ function createWorkerClient(workerUrl: URL | string): SearchWorkerClient {
           reject,
         });
         post({ type: 'RUN_SEARCH', requestId, query, options, pagination });
+      });
+    },
+
+    runSearchMany(
+      terms: string[],
+      options: AdvancedSearchOptions,
+      searchManyOptions: MultiTermOptions,
+    ): Promise<MultiTermResponse> {
+      const requestId = generateRequestId();
+      return new Promise<MultiTermResponse>((resolve, reject) => {
+        pending.set(requestId, {
+          resolve: resolve as PendingResolve,
+          reject,
+        });
+        post({ type: 'RUN_SEARCH_MANY', requestId, terms, options, searchManyOptions });
       });
     },
 
@@ -165,6 +188,32 @@ function createFallbackClient(deps: FallbackDependencies): SearchWorkerClient {
         },
         options,
         pagination,
+        undefined,
+        lruCache ?? undefined,
+      );
+    },
+
+    async runSearchMany(
+      terms: string[],
+      options: AdvancedSearchOptions,
+      searchManyOptions: MultiTermOptions,
+    ): Promise<MultiTermResponse> {
+      if (!ready) {
+        throw new WorkerNotInitializedError();
+      }
+      // Array overload of search() — routes internally to the multi-term path.
+      return search(
+        terms,
+        {
+          quranData: deps.quranData,
+          morphologyMap: deps.morphologyMap,
+          wordMap: deps.wordMap,
+          invertedIndex: deps.invertedIndex,
+          semanticMap: deps.semanticMap,
+          phoneticMap: deps.phoneticMap,
+        },
+        options,
+        searchManyOptions,
         undefined,
         lruCache ?? undefined,
       );

--- a/src/worker/search-worker.ts
+++ b/src/worker/search-worker.ts
@@ -11,7 +11,13 @@ import {
 import { search } from '../core/search';
 import { LRUCache } from '../utils/lru-cache';
 import type { QuranText, MorphologyAya, WordMap, SearchResponse, InvertedIndex } from '../types';
-import type { WorkerRequest, InitDataResponse, SearchResultResponse, ErrorResponse } from './types';
+import type {
+  WorkerRequest,
+  InitDataResponse,
+  SearchResultResponse,
+  SearchManyResultResponse,
+  ErrorResponse,
+} from './types';
 
 // ── Worker-scoped state ────────────────────────────────────────
 
@@ -25,7 +31,13 @@ const cache = new LRUCache<string, SearchResponse<QuranText>>(100);
 
 // ── Helpers ────────────────────────────────────────────────────
 
-function postTyped(msg: InitDataResponse | SearchResultResponse<QuranText> | ErrorResponse): void {
+function postTyped(
+  msg:
+    | InitDataResponse
+    | SearchResultResponse<QuranText>
+    | SearchManyResultResponse<QuranText>
+    | ErrorResponse,
+): void {
   postMessage(msg);
 }
 
@@ -99,6 +111,52 @@ self.onmessage = async (event: MessageEvent<WorkerRequest>) => {
 
         postTyped({
           type: 'SEARCH_RESULT',
+          requestId: msg.requestId,
+          data: result,
+          timingMs: performance.now() - start,
+        });
+      } catch (err) {
+        postTyped({
+          type: 'ERROR',
+          requestId: msg.requestId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      break;
+    }
+
+    case 'RUN_SEARCH_MANY': {
+      const start = performance.now();
+
+      if (!quranData || !morphologyMap || !wordMap) {
+        postTyped({
+          type: 'ERROR',
+          requestId: msg.requestId,
+          error: 'Worker data not initialized. Call INIT_DATA first.',
+        });
+        return;
+      }
+
+      try {
+        // Array overload of search() — routes internally to the multi-term path.
+        const result = search(
+          msg.terms,
+          {
+            quranData,
+            morphologyMap,
+            wordMap,
+            invertedIndex: invertedIndex ?? undefined,
+            semanticMap: semanticMap ?? undefined,
+            phoneticMap: phoneticMap ?? undefined,
+          },
+          msg.options,
+          msg.searchManyOptions,
+          undefined,
+          cache,
+        );
+
+        postTyped({
+          type: 'SEARCH_MANY_RESULT',
           requestId: msg.requestId,
           data: result,
           timingMs: performance.now() - start,

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -2,13 +2,19 @@ import type {
   AdvancedSearchOptions,
   PaginationOptions,
   SearchResponse,
+  MultiTermOptions,
+  MultiTermResponse,
   VerseInput,
 } from '../types';
 
 // ── Message types ──────────────────────────────────────────────
 
-export type WorkerMessageType = 'INIT_DATA' | 'RUN_SEARCH' | 'DISPOSE';
-export type WorkerResponseType = 'INIT_DATA_RESULT' | 'SEARCH_RESULT' | 'ERROR';
+export type WorkerMessageType = 'INIT_DATA' | 'RUN_SEARCH' | 'RUN_SEARCH_MANY' | 'DISPOSE';
+export type WorkerResponseType =
+  | 'INIT_DATA_RESULT'
+  | 'SEARCH_RESULT'
+  | 'SEARCH_MANY_RESULT'
+  | 'ERROR';
 
 // ── Request payloads (main → worker) ───────────────────────────
 
@@ -25,11 +31,23 @@ export type RunSearchRequest = {
   pagination: PaginationOptions;
 };
 
+export type RunSearchManyRequest = {
+  type: 'RUN_SEARCH_MANY';
+  requestId: string;
+  terms: string[];
+  options: AdvancedSearchOptions;
+  searchManyOptions: MultiTermOptions;
+};
+
 export type DisposeRequest = {
   type: 'DISPOSE';
 };
 
-export type WorkerRequest = InitDataRequest | RunSearchRequest | DisposeRequest;
+export type WorkerRequest =
+  | InitDataRequest
+  | RunSearchRequest
+  | RunSearchManyRequest
+  | DisposeRequest;
 
 // ── Response payloads (worker → main) ──────────────────────────
 
@@ -47,6 +65,13 @@ export type SearchResultResponse<TVerse extends VerseInput = VerseInput> = {
   timingMs: number;
 };
 
+export type SearchManyResultResponse<TVerse extends VerseInput = VerseInput> = {
+  type: 'SEARCH_MANY_RESULT';
+  requestId: string;
+  data: MultiTermResponse<TVerse>;
+  timingMs: number;
+};
+
 export type ErrorResponse = {
   type: 'ERROR';
   requestId: string;
@@ -56,6 +81,7 @@ export type ErrorResponse = {
 export type WorkerResponse<TVerse extends VerseInput = VerseInput> =
   | InitDataResponse
   | SearchResultResponse<TVerse>
+  | SearchManyResultResponse<TVerse>
   | ErrorResponse;
 
 // ── Client interface ───────────────────────────────────────────
@@ -70,6 +96,13 @@ export interface SearchWorkerClient {
     options: AdvancedSearchOptions,
     pagination: PaginationOptions,
   ): Promise<SearchResponse>;
+
+  /** Run an independent multi-term search inside the Worker and return the merged response. */
+  runSearchMany(
+    terms: string[],
+    options: AdvancedSearchOptions,
+    searchManyOptions: MultiTermOptions,
+  ): Promise<MultiTermResponse>;
 
   /** Terminate the underlying Worker. */
   terminate(): void;


### PR DESCRIPTION
#90 feat:add search many
Adds `searchMany()` for independent multi-term search , each term runs through the existing `search()` pipeline separately and results are merged by verse `gid`, with `score`/`coverage`/`frequency` ranking. Wired through the Web Worker and the vite-react demo (new "Multi-term mode" toggle) for testing.

