### PR TITLE
feat(cli): add quran-search-engine terminal command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CLI**: New `quran-search-engine` command for searching the Quran from a terminal, runnable via
+  `npx quran-search-engine "<query>"` or after a global install.
+- **CLI output formats**: `--format json|csv|tsv` and `--output <file>` for scripting, alongside matching,
+  scope, and pagination options that mirror the library's own defaults.
+
 ## [0.3.2]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -217,148 +217,26 @@ console.log(response.results[0]);
 
 ## CLI
 
-The package publishes a `quran-search-engine` command, so the engine can be queried from a terminal or a shell
-script without writing any code.
-
-Run it without installing anything:
+The package publishes a `quran-search-engine` command, so the engine can be queried from a
+terminal or a shell script without writing any code.
 
 ```bash
-npx quran-search-engine "رحم"
+npx quran-search-engine "رحم"                    # no install needed
+yarn global add quran-search-engine              # or install it globally
 ```
-
-Or install it globally:
 
 ```bash
-yarn global add quran-search-engine
+quran-search-engine "رحمة" --format json | jq .  # pipe into another tool
+quran-search-engine "الله" --sura 1 --limit 5    # narrow and page
+quran-search-engine "2:255"                      # verse coordinates, no flag needed
+quran-search-engine --help                       # every option, with its default
 ```
 
-<details> <summary>Other package managers</summary>
-<br>
-npm install -g quran-search-engine <br>
-pnpm add -g quran-search-engine <br>
+Exit codes are `0` when it completed, including when nothing matched, `1` for a runtime error
+and `2` for invalid usage, so scripts can tell those apart without reading the message.
 
-</details>
-
-Usage is one search per invocation:
-
-```bash
-quran-search-engine <query> [options]
-```
-
-Options accept their value either way, so `--limit 5` and `--limit=5` are equivalent.
-
-### CLI options
-
-Defaults are the library's own defaults, not choices made for the terminal.
-
-| Option                      | Value                    | Default        | Effect                       |
-| --------------------------- | ------------------------ | -------------- | ---------------------------- |
-| `--lemma` / `--no-lemma`    | —                        | on             | Word-family matching         |
-| `--root` / `--no-root`      | —                        | on             | Word-root matching           |
-| `--fuzzy` / `--no-fuzzy`    | —                        | on             | Approximate matching         |
-| `--semantic`                | —                        | off            | Related-concept matching     |
-| `--regex`                   | —                        | off            | Treat the query as a pattern |
-| `--sura <n>`                | 1 to 114                 | all            | Restrict to one sura         |
-| `--juz <n>`                 | 1 to 30                  | all            | Restrict to one juz          |
-| `--page <n>`                | positive integer         | `1`            | Which page of results        |
-| `--limit <n>`               | positive integer         | `20`           | Results per page             |
-| `--format <json\|csv\|tsv>` | `json` \| `csv` \| `tsv` | readable table | Machine-readable output      |
-| `--output <file>`           | file path                | stdout         | Write to a file instead      |
-| `-h`, `--help`              | —                        | —              | Show the help screen         |
-| `--version`                 | —                        | —              | Show the installed version   |
-
-The same list, with defaults, is printed by `quran-search-engine --help`.
-
-### Exit codes
-
-| Code | Meaning       | Examples                                                   |
-| ---- | ------------- | ---------------------------------------------------------- |
-| `0`  | completed     | Results found, and also when nothing matched               |
-| `1`  | runtime error | Data could not be loaded, output file could not be written |
-| `2`  | invalid usage | Unknown option, missing or blank query, bad value          |
-
-Scripts can therefore distinguish "nothing matched" from a real failure without parsing message text.
-
-### Query shapes recognised without a flag
-
-These are detected from the query itself, so no option enables them:
-
-| Shape                 | Example                                          | Behaviour                     |
-| --------------------- | ------------------------------------------------ | ----------------------------- |
-| Verse coordinates     | `2:255`, `1:1-7`, `2:`                           | Returns those verses directly |
-| Logical operators     | `الله AND (الرحمن OR الرحيم)`, `الله NOT الرحمن` | Operators are honoured        |
-| Latin transliteration | `rahman`, `bismi allah`                          | Treated as a transliteration  |
-
-```bash
-quran-search-engine "2:255"
-quran-search-engine "الله NOT الرحمن"
-quran-search-engine "rahman"
-```
-
-Transliteration is matched word by word, so write each word separately — `bismi allah` rather
-than `bismillah`.
-
-### Output formats
-
-Without `--format`, results are printed as a readable table: one line per verse, then the totals.
-
-```bash
-quran-search-engine "رحم"
-```
-
-With `--format json`, the output is an array of verse objects:
-
-```bash
-quran-search-engine "رحم" --format json
-```
-
-With `--format csv`, the output starts with a UTF-8 BOM (so spreadsheets open Arabic text correctly),
-followed by the columns `sura,aya,score,matchType,text`:
-
-```bash
-quran-search-engine "رحم" --format csv --output results.csv
-```
-
-`--format tsv` produces the same columns, tab-separated:
-
-```bash
-quran-search-engine "رحم" --format tsv
-```
-
-Machine-readable output contains only the data — no headings, totals, or progress messages — so it can be piped
-straight into another tool:
-
-```bash
-quran-search-engine "رحمة" --format json | jq .
-```
-
-### Custom data
-
-Custom data loading (`--quran <file>` / `--data-dir <dir>`) is not supported by the CLI; it always searches the
-bundled dataset. Custom datasets remain available through the library API, and CLI support for them is tracked
-as separate future work.
-
-### Running the CLI from source
-
-Contributors do not need to install the package. Build once, then run the built entry point
-directly:
-
-```bash
-yarn install
-yarn build
-node dist/cli.js "رحم"
-node dist/cli.js --help
-```
-
-Rebuild after changing anything under `src/`, since `dist/` is what the command runs. To
-exercise it exactly as a published user would, including the `bin` link and the shebang, pack
-and install the tarball into a throwaway prefix:
-
-```bash
-npm pack --pack-destination /tmp/qse
-npm install --prefix /tmp/qse /tmp/qse/quran-search-engine-*.tgz
-/tmp/qse/node_modules/.bin/quran-search-engine "رحم"
-```
+See the [CLI guide](./docs/cli.md) for the full option list, the output formats, the query
+shapes that need no flag, and how to run it from a source checkout.
 
 ## Public API
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Usage is one search per invocation:
 quran-search-engine <query> [options]
 ```
 
+Options accept their value either way, so `--limit 5` and `--limit=5` are equivalent.
+
 ### CLI options
 
 Defaults are the library's own defaults, not choices made for the terminal.
@@ -256,8 +258,8 @@ Defaults are the library's own defaults, not choices made for the terminal.
 | `--fuzzy` / `--no-fuzzy`    | —                        | on             | Approximate matching         |
 | `--semantic`                | —                        | off            | Related-concept matching     |
 | `--regex`                   | —                        | off            | Treat the query as a pattern |
-| `--sura <n>`                | positive integer         | all            | Restrict to one sura         |
-| `--juz <n>`                 | positive integer         | all            | Restrict to one juz          |
+| `--sura <n>`                | 1 to 114                 | all            | Restrict to one sura         |
+| `--juz <n>`                 | 1 to 30                  | all            | Restrict to one juz          |
 | `--page <n>`                | positive integer         | `1`            | Which page of results        |
 | `--limit <n>`               | positive integer         | `20`           | Results per page             |
 | `--format <json\|csv\|tsv>` | `json` \| `csv` \| `tsv` | readable table | Machine-readable output      |
@@ -335,6 +337,28 @@ quran-search-engine "رحمة" --format json | jq .
 Custom data loading (`--quran <file>` / `--data-dir <dir>`) is not supported by the CLI; it always searches the
 bundled dataset. Custom datasets remain available through the library API, and CLI support for them is tracked
 as separate future work.
+
+### Running the CLI from source
+
+Contributors do not need to install the package. Build once, then run the built entry point
+directly:
+
+```bash
+yarn install
+yarn build
+node dist/cli.js "رحم"
+node dist/cli.js --help
+```
+
+Rebuild after changing anything under `src/`, since `dist/` is what the command runs. To
+exercise it exactly as a published user would, including the `bin` link and the shebang, pack
+and install the tarball into a throwaway prefix:
+
+```bash
+npm pack --pack-destination /tmp/qse
+npm install --prefix /tmp/qse /tmp/qse/quran-search-engine-*.tgz
+/tmp/qse/node_modules/.bin/quran-search-engine "رحم"
+```
 
 ## Public API
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ quran-search-engine --help                       # every option, with its defaul
 Exit codes are `0` when it completed, including when nothing matched, `1` for a runtime error
 and `2` for invalid usage, so scripts can tell those apart without reading the message.
 
-See the [CLI guide](./docs/cli.md) for the full option list, the output formats, the query
+See the [CLI guide](./docs/guides/cli.md) for the full option list, the output formats, the query
 shapes that need no flag, and how to run it from a source checkout.
 
 ## Public API

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Stateless, UI-agnostic Quran (Qur'an) search engine for Arabic text in pure Type
 - [Installation](#installation)
 - [Development Setup](#development-setup)
 - [Quickstart](#quickstart)
+- [CLI](#cli)
 - [Public API](#public-api)
 - [Error Handling](#error-handling)
 - [How scoring works](#how-scoring-works)
@@ -213,6 +214,127 @@ console.log(response.results[0]);
 
 > [!IMPORTANT]
 > **Note for Developers**: This project uses a yarn workspace with `workspace:*` links. If you make changes to the library's source code in `src/`, you **must build the library** using `yarn build` (or run it in watch mode with `yarn build --watch`) for those changes to be reflected in the example applications.
+
+## CLI
+
+The package publishes a `quran-search-engine` command, so the engine can be queried from a terminal or a shell
+script without writing any code.
+
+Run it without installing anything:
+
+```bash
+npx quran-search-engine "رحم"
+```
+
+Or install it globally:
+
+```bash
+yarn global add quran-search-engine
+```
+
+<details> <summary>Other package managers</summary>
+<br>
+npm install -g quran-search-engine <br>
+pnpm add -g quran-search-engine <br>
+
+</details>
+
+Usage is one search per invocation:
+
+```bash
+quran-search-engine <query> [options]
+```
+
+### CLI options
+
+Defaults are the library's own defaults, not choices made for the terminal.
+
+| Option                      | Value                    | Default        | Effect                       |
+| --------------------------- | ------------------------ | -------------- | ---------------------------- |
+| `--lemma` / `--no-lemma`    | —                        | on             | Word-family matching         |
+| `--root` / `--no-root`      | —                        | on             | Word-root matching           |
+| `--fuzzy` / `--no-fuzzy`    | —                        | on             | Approximate matching         |
+| `--semantic`                | —                        | off            | Related-concept matching     |
+| `--regex`                   | —                        | off            | Treat the query as a pattern |
+| `--sura <n>`                | positive integer         | all            | Restrict to one sura         |
+| `--juz <n>`                 | positive integer         | all            | Restrict to one juz          |
+| `--page <n>`                | positive integer         | `1`            | Which page of results        |
+| `--limit <n>`               | positive integer         | `20`           | Results per page             |
+| `--format <json\|csv\|tsv>` | `json` \| `csv` \| `tsv` | readable table | Machine-readable output      |
+| `--output <file>`           | file path                | stdout         | Write to a file instead      |
+| `-h`, `--help`              | —                        | —              | Show the help screen         |
+| `--version`                 | —                        | —              | Show the installed version   |
+
+The same list, with defaults, is printed by `quran-search-engine --help`.
+
+### Exit codes
+
+| Code | Meaning       | Examples                                                   |
+| ---- | ------------- | ---------------------------------------------------------- |
+| `0`  | completed     | Results found, and also when nothing matched               |
+| `1`  | runtime error | Data could not be loaded, output file could not be written |
+| `2`  | invalid usage | Unknown option, missing or blank query, bad value          |
+
+Scripts can therefore distinguish "nothing matched" from a real failure without parsing message text.
+
+### Query shapes recognised without a flag
+
+These are detected from the query itself, so no option enables them:
+
+| Shape                 | Example                                          | Behaviour                     |
+| --------------------- | ------------------------------------------------ | ----------------------------- |
+| Verse coordinates     | `2:255`, `1:1-7`, `2:`                           | Returns those verses directly |
+| Logical operators     | `الله AND (الرحمن OR الرحيم)`, `الله NOT الرحمن` | Operators are honoured        |
+| Latin transliteration | `rahman`, `bismi allah`                          | Treated as a transliteration  |
+
+```bash
+quran-search-engine "2:255"
+quran-search-engine "الله NOT الرحمن"
+quran-search-engine "rahman"
+```
+
+Transliteration is matched word by word, so write each word separately — `bismi allah` rather
+than `bismillah`.
+
+### Output formats
+
+Without `--format`, results are printed as a readable table: one line per verse, then the totals.
+
+```bash
+quran-search-engine "رحم"
+```
+
+With `--format json`, the output is an array of verse objects:
+
+```bash
+quran-search-engine "رحم" --format json
+```
+
+With `--format csv`, the output starts with a UTF-8 BOM (so spreadsheets open Arabic text correctly),
+followed by the columns `sura,aya,score,matchType,text`:
+
+```bash
+quran-search-engine "رحم" --format csv --output results.csv
+```
+
+`--format tsv` produces the same columns, tab-separated:
+
+```bash
+quran-search-engine "رحم" --format tsv
+```
+
+Machine-readable output contains only the data — no headings, totals, or progress messages — so it can be piped
+straight into another tool:
+
+```bash
+quran-search-engine "رحمة" --format json | jq .
+```
+
+### Custom data
+
+Custom data loading (`--quran <file>` / `--data-dir <dir>`) is not supported by the CLI; it always searches the
+bundled dataset. Custom datasets remain available through the library API, and CLI support for them is tracked
+as separate future work.
 
 ## Public API
 
@@ -1056,6 +1178,9 @@ Several example applications are available in the `examples/` directory:
 - **Vanilla TypeScript**: Simple browser-based search without frameworks (`examples/vanilla-ts`)
 - **Angular**: Standalone Angular app with highlighted results (`examples/angular`)
 - **Node.js**: Server-side search with command-line interface (`examples/nodejs`)
+
+The bundled [CLI](#cli) is another way to try the engine without writing any code:
+`npx quran-search-engine "رحم"`.
 
 ### Production Examples
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,162 @@
+# CLI
+
+The package publishes a `quran-search-engine` command, so the engine can be queried from a
+terminal or a shell script without writing any code. It is a thin wrapper over the library:
+options map onto the same arguments `search()` takes, and results come back unchanged.
+
+For a two-line introduction see the [CLI section of the README](../README.md#cli). This page
+covers the full surface.
+
+## Installation
+
+Run it without installing anything:
+
+```bash
+npx quran-search-engine "رحم"
+```
+
+Or install it globally:
+
+```bash
+yarn global add quran-search-engine
+```
+
+<details><summary>Other package managers</summary>
+<br>
+npm install -g quran-search-engine <br>
+pnpm add -g quran-search-engine <br>
+
+</details>
+
+## Usage
+
+```bash
+quran-search-engine <query> [options]
+```
+
+One search per invocation. Options accept their value either way, so `--limit 5` and
+`--limit=5` are equivalent. A multi-word query must be quoted, since two or more bare
+arguments are rejected.
+
+## Options
+
+Defaults are the library's own defaults, not choices made for the terminal.
+
+| Option                      | Value                    | Default        | Effect                       |
+| --------------------------- | ------------------------ | -------------- | ---------------------------- |
+| `--lemma` / `--no-lemma`    | —                        | on             | Word-family matching         |
+| `--root` / `--no-root`      | —                        | on             | Word-root matching           |
+| `--fuzzy` / `--no-fuzzy`    | —                        | on             | Approximate matching         |
+| `--semantic`                | —                        | off            | Related-concept matching     |
+| `--regex`                   | —                        | off            | Treat the query as a pattern |
+| `--sura <n>`                | 1 to 114                 | all            | Restrict to one sura         |
+| `--juz <n>`                 | 1 to 30                  | all            | Restrict to one juz          |
+| `--page <n>`                | positive integer         | `1`            | Which page of results        |
+| `--limit <n>`               | positive integer         | `20`           | Results per page             |
+| `--format <json\|csv\|tsv>` | `json` \| `csv` \| `tsv` | readable table | Machine-readable output      |
+| `--output <file>`           | file path                | stdout         | Write to a file instead      |
+| `-h`, `--help`              | —                        | —              | Show the help screen         |
+| `--version`                 | —                        | —              | Show the installed version   |
+
+`--sura` and `--juz` are bounded because they name real divisions of the mushaf: a value
+outside the range is rejected rather than answered with an empty result set, since returning
+nothing would read as "that sura holds no matches". `--page` and `--limit` are unbounded,
+because they address result pages.
+
+The same list, with defaults, is printed by `quran-search-engine --help`.
+
+## Query shapes recognised without a flag
+
+These are detected from the query itself, so no option enables them:
+
+| Shape                 | Example                                          | Behaviour                     |
+| --------------------- | ------------------------------------------------ | ----------------------------- |
+| Verse coordinates     | `2:255`, `1:1-7`, `2:`                           | Returns those verses directly |
+| Logical operators     | `الله AND (الرحمن OR الرحيم)`, `الله NOT الرحمن` | Operators are honoured        |
+| Latin transliteration | `rahman`, `bismi allah`                          | Treated as a transliteration  |
+
+```bash
+quran-search-engine "2:255"
+quran-search-engine "الله NOT الرحمن"
+quran-search-engine "rahman"
+```
+
+Transliteration is matched word by word, so write each word separately: `bismi allah` rather
+than `bismillah`.
+
+## Output
+
+Without `--format`, results print as a readable table: one line per verse, then the totals,
+then a breakdown of which kinds of matching produced them. Kinds that produced nothing are
+left out.
+
+```text
+1:1  بسم الله الرحمن الرحيم
+1:3  الرحمن الرحيم
+
+Showing 2 of 313 results (page 1 of 157)
+Matches: exact 201 · fuzzy 112
+```
+
+Note that `fuzzy` currently includes unscored matches, which is a quirk of the library's own
+counts rather than of the CLI. Tracked in
+[#102](https://github.com/adelpro/quran-search-engine/issues/102).
+
+`--format` produces machine-readable output instead, delegated to `exportResults` so the
+shapes are identical to the library's:
+
+```bash
+quran-search-engine "رحمة" --format json | jq .
+quran-search-engine "رحمة" --format csv > results.csv
+quran-search-engine "رحمة" --format tsv
+```
+
+- `json` is an array of verse objects.
+- `csv` starts with a UTF-8 BOM, then the columns `sura,aya,score,matchType,text`.
+- `tsv` is the same, tab-separated.
+
+Machine-readable output contains only the data, with no headings or totals mixed in, so it can
+be piped straight into another tool. With `--output`, the chosen format is written to that file
+and nothing goes to stdout.
+
+Results always go to stdout and diagnostics to stderr, so redirecting one never contaminates
+the other.
+
+## Exit codes
+
+| Code | Meaning       | Examples                                                   |
+| ---- | ------------- | ---------------------------------------------------------- |
+| `0`  | completed     | Results found, and also when nothing matched               |
+| `1`  | runtime error | Data could not be loaded, output file could not be written |
+| `2`  | invalid usage | Unknown option, missing or blank query, value out of range |
+
+Scripts can therefore tell "nothing matched" from a real failure without parsing any message
+text.
+
+## Running the CLI from source
+
+Contributors do not need to install the package. Build once, then run the built entry point:
+
+```bash
+yarn install
+yarn build
+node dist/cli.js "رحم"
+node dist/cli.js --help
+```
+
+Rebuild after changing anything under `src/`, since `dist/` is what the command runs.
+
+To exercise it exactly as a published user would, including the `bin` link and the shebang,
+pack and install the tarball into a throwaway prefix:
+
+```bash
+npm pack --pack-destination /tmp/qse
+npm install --prefix /tmp/qse /tmp/qse/quran-search-engine-*.tgz
+/tmp/qse/node_modules/.bin/quran-search-engine "رحم"
+```
+
+## Custom data
+
+Custom data loading (`--quran <file>` / `--data-dir <dir>`) is not supported by the CLI; it
+always searches the bundled dataset. Custom datasets remain available through the library API,
+and CLI support for them is tracked as separate future work.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -4,7 +4,7 @@ The package publishes a `quran-search-engine` command, so the engine can be quer
 terminal or a shell script without writing any code. It is a thin wrapper over the library:
 options map onto the same arguments `search()` takes, and results come back unchanged.
 
-For a two-line introduction see the [CLI section of the README](../README.md#cli). This page
+For a two-line introduction see the [CLI section of the README](../../README.md#cli). This page
 covers the full surface.
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,10 +24,10 @@ This library provides a deterministic and highly customizable search experience 
 - [Project Description & Getting Started](./guides/getting-started.md)
 - [Installation Guide](./guides/installation.md)
 - [Quick Start](./guides/quick-start.md)
-- [CLI](./cli.md)
 
 ### Guides
 
+- [CLI](./guides/cli.md)
 - [Search Syntax & Scoring](./guides/search-syntax.md)
 - [Advanced Configuration](./guides/configuration.md)
 - [Examples & Integrations](./guides/examples.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ This library provides a deterministic and highly customizable search experience 
 - [Project Description & Getting Started](./guides/getting-started.md)
 - [Installation Guide](./guides/installation.md)
 - [Quick Start](./guides/quick-start.md)
+- [CLI](./cli.md)
 
 ### Guides
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "bin": "./dist/cli.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,35 @@
+import { run } from './cli/run';
+
+/**
+ * Executable entry point. The only file that touches `process` — all logic lives in
+ * `cli/run.ts`, which returns an exit code instead of terminating.
+ */
+const main = async (): Promise<void> => {
+  // `quran-search-engine "رحمة" --format json | head -1` closes the pipe while we are still
+  // writing. That is an ordinary shell idiom, so exit quietly instead of reporting a crash.
+  const exitQuietlyOnBrokenPipe = (error: Error & { code?: string }): void => {
+    if (error.code === 'EPIPE') {
+      process.exit(0);
+    }
+    throw error;
+  };
+  process.stdout.on('error', exitQuietlyOnBrokenPipe);
+  process.stderr.on('error', exitQuietlyOnBrokenPipe);
+
+  const code = await run(process.argv.slice(2), {
+    stdout: (text) => {
+      process.stdout.write(text);
+    },
+    stderr: (text) => {
+      process.stderr.write(text);
+    },
+  });
+
+  // Set the code and let the process end on its own. Calling process.exit() here would
+  // discard whatever is still queued in stdout: when stdout is a pipe, writes are
+  // asynchronous, and anything past the 64 KB pipe buffer had not been flushed yet — so
+  // `--format json | jq .` silently received truncated JSON.
+  process.exitCode = code;
+};
+
+void main();

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -127,6 +127,34 @@ describe('parseArgs', () => {
     it('rejects a numeric option with no value', () => {
       expect(parseError(['رحم', '--sura']).message).toMatch(/needs a value/i);
     });
+
+    it.each([
+      ['--sura', '115', '1 to 114'],
+      ['--sura', '999', '1 to 114'],
+      ['--juz', '31', '1 to 30'],
+    ])('rejects %s %s as out of range', (flag, value, expected) => {
+      // Out of range is a usage mistake. Returning nothing would read as "no matches in that
+      // sura" when the sura does not exist.
+      const error = parseError(['رحم', flag, value]);
+
+      expect(error.flag).toBe(flag);
+      expect(error.message).toContain(expected);
+    });
+
+    it.each([
+      ['--sura', '114'],
+      ['--juz', '30'],
+    ])('accepts %s %s at the upper bound', (flag, value) => {
+      expect(isUsageError(parseArgs(['رحم', flag, value]))).toBe(false);
+    });
+
+    it.each(['--page', '--limit'])('leaves %s unbounded, since it paginates results', (flag) => {
+      expect(parseOk(['رحم', flag, '99999']).pagination).toMatchObject({});
+    });
+
+    it('mentions the range when a bounded flag is missing its value', () => {
+      expect(parseError(['رحم', '--juz']).message).toContain('1 to 30');
+    });
   });
 
   describe('output options', () => {

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import { isUsageError, parseArgs, type CliOptions } from './args';
+
+/** Parses and asserts success, returning the options for further assertions. */
+const parseOk = (argv: string[]): CliOptions => {
+  const result = parseArgs(argv);
+  if (isUsageError(result)) {
+    throw new Error(`expected success but got usage error: ${result.message}`);
+  }
+  return result;
+};
+
+/** Parses and asserts a usage error, returning it for message assertions. */
+const parseError = (argv: string[]): { message: string; flag?: string } => {
+  const result = parseArgs(argv);
+  if (!isUsageError(result)) {
+    throw new Error('expected a usage error but parsing succeeded');
+  }
+  return result;
+};
+
+describe('parseArgs', () => {
+  describe('defaults', () => {
+    it('mirrors the library defaults', () => {
+      const parsed = parseOk(['رحم']);
+
+      expect(parsed.query).toBe('رحم');
+      expect(parsed.mode).toBe('search');
+      expect(parsed.options).toMatchObject({
+        lemma: true,
+        root: true,
+        fuzzy: true,
+        semantic: false,
+        isRegex: false,
+      });
+      expect(parsed.pagination).toEqual({ page: 1, limit: 20 });
+      expect(parsed.format).toBe('table');
+      expect(parsed.output).toBeUndefined();
+      expect(parsed.warnings).toEqual([]);
+    });
+
+    it('applies no sura or juz filter by default', () => {
+      const parsed = parseOk(['رحم']);
+
+      expect(parsed.options.suraId).toBeUndefined();
+      expect(parsed.options.juzId).toBeUndefined();
+    });
+  });
+
+  describe('query handling', () => {
+    it('rejects a missing query', () => {
+      expect(parseError([]).message).toMatch(/query is required/i);
+    });
+
+    it.each([
+      ['empty string', ''],
+      ['spaces', '   '],
+      ['a tab', '\t'],
+    ])('rejects a blank query (%s)', (_label, query) => {
+      // The library throws InvalidQueryError for these; rejecting here keeps that off the
+      // runtime path, where it would report as a runtime fault rather than a usage error.
+      expect(parseError([query]).message).toMatch(/query is empty/i);
+    });
+
+    it.each(['!!!', '...'])('accepts a punctuation-only query (%s)', (query) => {
+      // Not blank: this is a valid search that simply matches nothing.
+      expect(parseOk([query]).query).toBe(query);
+    });
+
+    it('rejects several positionals and says to quote the query', () => {
+      const error = parseError(['الله', 'الرحمن']);
+
+      expect(error.message).toMatch(/single query/i);
+      expect(error.message).toMatch(/quote/i);
+    });
+  });
+
+  describe('help and version', () => {
+    it.each(['--help', '-h'])('treats %s as a mode rather than exiting', (flag) => {
+      expect(parseOk([flag]).mode).toBe('help');
+    });
+
+    it('treats --version as a mode rather than exiting', () => {
+      expect(parseOk(['--version']).mode).toBe('version');
+    });
+
+    it('does not require a query for help or version', () => {
+      expect(isUsageError(parseArgs(['--help']))).toBe(false);
+      expect(isUsageError(parseArgs(['--version']))).toBe(false);
+    });
+  });
+
+  describe('matching toggles', () => {
+    it.each([
+      ['--no-lemma', 'lemma'],
+      ['--no-root', 'root'],
+      ['--no-fuzzy', 'fuzzy'],
+    ] as const)('%s turns off %s', (flag, key) => {
+      expect(parseOk(['رحم', flag]).options[key]).toBe(false);
+    });
+
+    it.each([
+      ['--semantic', 'semantic'],
+      ['--regex', 'isRegex'],
+    ] as const)('%s turns on %s', (flag, key) => {
+      expect(parseOk(['رحم', flag]).options[key]).toBe(true);
+    });
+  });
+
+  describe('numeric options', () => {
+    it('parses page, limit, sura and juz', () => {
+      const parsed = parseOk(['رحم', '--page', '3', '--limit', '5', '--sura', '2', '--juz', '1']);
+
+      expect(parsed.pagination).toEqual({ page: 3, limit: 5 });
+      expect(parsed.options.suraId).toBe(2);
+      expect(parsed.options.juzId).toBe(1);
+    });
+
+    it('accepts the --flag=value form', () => {
+      expect(parseOk(['رحم', '--page=4']).pagination.page).toBe(4);
+    });
+
+    it.each(['0', '-1', 'abc', '1.5'])('rejects --limit %s', (value) => {
+      expect(parseError(['رحم', '--limit', value]).flag).toBe('--limit');
+    });
+
+    it('rejects a numeric option with no value', () => {
+      expect(parseError(['رحم', '--sura']).message).toMatch(/needs a value/i);
+    });
+  });
+
+  describe('output options', () => {
+    it.each(['json', 'csv', 'tsv'] as const)('accepts --format %s', (format) => {
+      expect(parseOk(['رحم', '--format', format]).format).toBe(format);
+    });
+
+    it('rejects an unsupported format and names the supported ones', () => {
+      const error = parseError(['رحم', '--format', 'yaml']);
+
+      expect(error.message).toContain('json');
+      expect(error.message).toContain('csv');
+      expect(error.message).toContain('tsv');
+    });
+
+    it('rejects --format with no value', () => {
+      expect(parseError(['رحم', '--format']).flag).toBe('--format');
+    });
+
+    it('captures --output', () => {
+      expect(parseOk(['رحم', '--output', 'results.json']).output).toBe('results.json');
+    });
+
+    it('rejects --output with no value', () => {
+      expect(parseError(['رحم', '--output']).message).toMatch(/file path/i);
+    });
+  });
+
+  describe('unknown options', () => {
+    it('rejects rather than ignoring, and names the flag', () => {
+      const error = parseError(['رحم', '--nonsense']);
+
+      expect(error.flag).toBe('--nonsense');
+      expect(error.message).toContain('--nonsense');
+      expect(error.message).toMatch(/--help/);
+    });
+  });
+
+  describe('repeated options', () => {
+    it('takes the last value of a repeated valued option', () => {
+      expect(parseOk(['رحم', '--page', '2', '--page', '3']).pagination.page).toBe(3);
+    });
+
+    it.each([
+      [['--lemma', '--no-lemma'], false],
+      [['--no-lemma', '--lemma'], true],
+    ] as const)('resolves %s to the last occurrence', (flags, expected) => {
+      expect(parseOk(['رحم', ...flags]).options.lemma).toBe(expected);
+    });
+  });
+
+  describe('regex warnings', () => {
+    it.each(['--lemma', '--root', '--fuzzy', '--semantic'])(
+      'warns that %s has no effect with --regex',
+      (flag) => {
+        const parsed = parseOk(['رحم', '--regex', flag]);
+
+        expect(parsed.warnings).toHaveLength(1);
+        expect(parsed.warnings[0]).toContain(flag);
+      },
+    );
+
+    it('collects one warning listing every ignored option', () => {
+      const parsed = parseOk(['رحم', '--regex', '--lemma', '--semantic']);
+
+      expect(parsed.warnings).toHaveLength(1);
+      expect(parsed.warnings[0]).toContain('--lemma');
+      expect(parsed.warnings[0]).toContain('--semantic');
+    });
+
+    it('does not warn when --regex is used alone', () => {
+      expect(parseOk(['رحم', '--regex']).warnings).toEqual([]);
+    });
+
+    it('does not warn about defaults the user did not ask for', () => {
+      // lemma/root/fuzzy default to on; only an explicit flag earns a warning.
+      expect(parseOk(['^.*ون$', '--regex']).warnings).toEqual([]);
+    });
+  });
+});

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,235 @@
+import type { AdvancedSearchOptions, PaginationOptions } from '../types';
+import type { ExportFormat } from '../utils/export';
+
+/** Output shapes the CLI can produce: the machine-readable ones plus the default table. */
+export type OutputFormat = ExportFormat | 'table';
+
+/** What the invocation is asking for. `help` and `version` are parse outcomes, not exits. */
+export type CliMode = 'search' | 'help' | 'version';
+
+/**
+ * A fully parsed command line, grouped so `run` can hand each part straight to `search()`
+ * without rearranging fields.
+ */
+export type CliOptions = {
+  query: string;
+  options: AdvancedSearchOptions;
+  pagination: PaginationOptions;
+  format: OutputFormat;
+  output?: string;
+  mode: CliMode;
+  /** Non-fatal diagnostics collected while parsing. Written by `run`, never by the parser. */
+  warnings: string[];
+};
+
+/** Returned rather than thrown, so callers keep usage errors distinct from runtime faults. */
+export type CliUsageError = {
+  message: string;
+  flag?: string;
+};
+
+const EXPORT_FORMATS: readonly ExportFormat[] = ['json', 'csv', 'tsv'];
+
+/** Options the regex layer ignores; combining them with `--regex` earns a warning. */
+const REGEX_IGNORED_FLAGS = ['--lemma', '--root', '--fuzzy', '--semantic'] as const;
+
+/** Narrows a parse result to the error case. */
+export const isUsageError = (result: CliOptions | CliUsageError): result is CliUsageError =>
+  'message' in result;
+
+const usageError = (message: string, flag?: string): CliUsageError => ({ message, flag });
+
+/**
+ * Parses a positive integer, rejecting `0`, negatives, decimals and non-numeric input.
+ * Shared by `--page`, `--limit`, `--sura` and `--juz` so their messages stay consistent.
+ */
+const parsePositiveInteger = (flag: string, raw: string | undefined): number | CliUsageError => {
+  if (raw === undefined || raw === '') {
+    return usageError(
+      `${flag} needs a value: a positive whole number, for example ${flag} 2`,
+      flag,
+    );
+  }
+
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    return usageError(
+      `${flag} must be a positive whole number, but got "${raw}". Use ${flag} 2 or higher.`,
+      flag,
+    );
+  }
+
+  return value;
+};
+
+/**
+ * Parses argv into `CliOptions`, or returns a `CliUsageError` describing what to change.
+ *
+ * Pure: no filesystem, no process, no output. Every default matches the library's own
+ * defaults so terminal results match `search()` for the same query.
+ *
+ * @param argv - Arguments after the node binary and script path.
+ * @returns Parsed options, or a usage error.
+ */
+export const parseArgs = (argv: string[]): CliOptions | CliUsageError => {
+  const options: AdvancedSearchOptions = {
+    lemma: true,
+    root: true,
+    fuzzy: true,
+    semantic: false,
+    isRegex: false,
+  };
+  const pagination: PaginationOptions = { page: 1, limit: 20 };
+  const positionals: string[] = [];
+  const explicitFlags = new Set<string>();
+
+  let format: OutputFormat = 'table';
+  let output: string | undefined;
+  let mode: CliMode = 'search';
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === undefined) continue;
+
+    if (!argument.startsWith('-') || argument === '-') {
+      positionals.push(argument);
+      continue;
+    }
+
+    // Support both "--flag value" and "--flag=value".
+    const separator = argument.indexOf('=');
+    const flag = separator === -1 ? argument : argument.slice(0, separator);
+    const inlineValue = separator === -1 ? undefined : argument.slice(separator + 1);
+    const takeValue = (): string | undefined => {
+      if (inlineValue !== undefined) return inlineValue;
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith('-')) return undefined;
+      index += 1;
+      return next;
+    };
+
+    explicitFlags.add(flag);
+
+    switch (flag) {
+      case '--help':
+      case '-h':
+        mode = 'help';
+        break;
+      case '--version':
+        mode = 'version';
+        break;
+
+      case '--lemma':
+        options.lemma = true;
+        break;
+      case '--no-lemma':
+        options.lemma = false;
+        break;
+      case '--root':
+        options.root = true;
+        break;
+      case '--no-root':
+        options.root = false;
+        break;
+      case '--fuzzy':
+        options.fuzzy = true;
+        break;
+      case '--no-fuzzy':
+        options.fuzzy = false;
+        break;
+      case '--semantic':
+        options.semantic = true;
+        break;
+      case '--regex':
+        options.isRegex = true;
+        break;
+
+      case '--sura':
+      case '--juz':
+      case '--page':
+      case '--limit': {
+        const value = parsePositiveInteger(flag, takeValue());
+        if (typeof value !== 'number') return value;
+        if (flag === '--sura') options.suraId = value;
+        else if (flag === '--juz') options.juzId = value;
+        else if (flag === '--page') pagination.page = value;
+        else pagination.limit = value;
+        break;
+      }
+
+      case '--format': {
+        const value = takeValue();
+        if (value === undefined) {
+          return usageError(
+            `--format needs a value. Available formats: ${EXPORT_FORMATS.join(', ')}.`,
+            flag,
+          );
+        }
+        if (!EXPORT_FORMATS.includes(value as ExportFormat)) {
+          return usageError(
+            `--format does not support "${value}". Available formats: ${EXPORT_FORMATS.join(', ')}.`,
+            flag,
+          );
+        }
+        format = value as ExportFormat;
+        break;
+      }
+
+      case '--output': {
+        const value = takeValue();
+        if (value === undefined) {
+          return usageError('--output needs a file path, for example --output results.json', flag);
+        }
+        output = value;
+        break;
+      }
+
+      default:
+        return usageError(
+          `Unknown option "${flag}". Run with --help to see the available options.`,
+          flag,
+        );
+    }
+  }
+
+  // --help and --version answer without a query, so stop before query validation.
+  if (mode !== 'search') {
+    return { query: '', options, pagination, format, output, mode, warnings: [] };
+  }
+
+  if (positionals.length === 0) {
+    return usageError(
+      'A search query is required. For example: quran-search-engine "رحم" — run with --help for options.',
+    );
+  }
+
+  if (positionals.length > 1) {
+    return usageError(
+      `Expected a single query but received ${positionals.length} arguments. Quote the whole query, for example: quran-search-engine "الله الرحمن"`,
+    );
+  }
+
+  const query = positionals[0] ?? '';
+
+  // A blank query is the same mistake as no query. Rejecting it here keeps the library's
+  // InvalidQueryError off the runtime path, where it would surface as a runtime fault
+  // instead of the usage error it is. Punctuation-only queries are not blank: they search
+  // normally and simply match nothing.
+  if (query.trim() === '') {
+    return usageError(
+      'The search query is empty. Provide a word or phrase to search for, for example: quran-search-engine "رحم"',
+    );
+  }
+
+  const warnings: string[] = [];
+  if (options.isRegex) {
+    const ignored = REGEX_IGNORED_FLAGS.filter((candidate) => explicitFlags.has(candidate));
+    if (ignored.length > 0) {
+      warnings.push(
+        `${ignored.join(', ')} has no effect with --regex: pattern matching runs on its own and skips lemma, root, fuzzy and semantic matching. Remove --regex to use them.`,
+      );
+    }
+  }
+
+  return { query, options, pagination, format, output, mode, warnings };
+};

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -30,6 +30,12 @@ export type CliUsageError = {
 
 const EXPORT_FORMATS: readonly ExportFormat[] = ['json', 'csv', 'tsv'];
 
+// Fixed properties of the mushaf, so they are safe to state here. Deliberately not derived
+// from the exported SURAS constant: that module imports quran.json at load time, and pulling
+// the corpus into the parser would make even `--help` pay for it.
+const SURA_COUNT = 114;
+const JUZ_COUNT = 30;
+
 /** Options the regex layer ignores; combining them with `--regex` earns a warning. */
 const REGEX_IGNORED_FLAGS = ['--lemma', '--root', '--fuzzy', '--semantic'] as const;
 
@@ -42,21 +48,36 @@ const usageError = (message: string, flag?: string): CliUsageError => ({ message
 /**
  * Parses a positive integer, rejecting `0`, negatives, decimals and non-numeric input.
  * Shared by `--page`, `--limit`, `--sura` and `--juz` so their messages stay consistent.
+ *
+ * @param flag - The flag being parsed, used in the message.
+ * @param raw - The raw value, if one was supplied.
+ * @param max - Upper bound, for flags that address a fixed range like suras or juz.
+ * @returns The parsed number, or a usage error explaining what to change.
  */
-const parsePositiveInteger = (flag: string, raw: string | undefined): number | CliUsageError => {
+const parsePositiveInteger = (
+  flag: string,
+  raw: string | undefined,
+  max?: number,
+): number | CliUsageError => {
+  const expected =
+    max === undefined ? 'a positive whole number' : `a whole number from 1 to ${max}`;
+
   if (raw === undefined || raw === '') {
-    return usageError(
-      `${flag} needs a value: a positive whole number, for example ${flag} 2`,
-      flag,
-    );
+    return usageError(`${flag} needs a value: ${expected}, for example ${flag} 2`, flag);
   }
 
   const value = Number(raw);
   if (!Number.isInteger(value) || value < 1) {
     return usageError(
-      `${flag} must be a positive whole number, but got "${raw}". Use ${flag} 2 or higher.`,
+      `${flag} must be ${expected}, but got "${raw}". Use ${flag} 2 or higher.`,
       flag,
     );
+  }
+
+  // Out of range is a usage mistake, not an empty search: returning nothing for --sura 999
+  // reads as "this sura has no matches" when the sura does not exist at all.
+  if (max !== undefined && value > max) {
+    return usageError(`${flag} must be ${expected}, but got "${raw}".`, flag);
   }
 
   return value;
@@ -148,7 +169,8 @@ export const parseArgs = (argv: string[]): CliOptions | CliUsageError => {
       case '--juz':
       case '--page':
       case '--limit': {
-        const value = parsePositiveInteger(flag, takeValue());
+        const bound = flag === '--sura' ? SURA_COUNT : flag === '--juz' ? JUZ_COUNT : undefined;
+        const value = parsePositiveInteger(flag, takeValue(), bound);
         if (typeof value !== 'number') return value;
         if (flag === '--sura') options.suraId = value;
         else if (flag === '--juz') options.juzId = value;

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import type { QuranText, ScoredVerse, SearchResponse } from '../types';
+import { formatResults, formatTable, helpText } from './format';
+
+const verse = (sura: number, aya: number, standard: string): ScoredVerse<QuranText> => ({
+  gid: aya,
+  sura_id: sura,
+  aya_id: aya,
+  aya_id_display: String(aya),
+  uthmani: standard,
+  standard,
+  standard_full: standard,
+  page_id: 1,
+  juz_id: 1,
+  sura_name: 'الفاتحة',
+  sura_name_en: 'The Opening',
+  sura_name_romanization: 'Al-Fatihah',
+  matchScore: 3,
+  matchType: 'exact',
+  matchedTokens: [],
+});
+
+const response = (
+  results: ScoredVerse<QuranText>[],
+  totalResults = results.length,
+  currentPage = 1,
+  limit = 20,
+): SearchResponse<QuranText> => ({
+  results,
+  counts: {
+    simple: results.length,
+    lemma: 0,
+    root: 0,
+    fuzzy: 0,
+    range: 0,
+    semantic: 0,
+    regex: 0,
+    total: totalResults,
+  },
+  pagination: {
+    totalResults,
+    totalPages: Math.max(1, Math.ceil(totalResults / limit)),
+    currentPage,
+    limit,
+  },
+});
+
+describe('formatTable', () => {
+  it('renders each verse with its sura and aya reference and text', () => {
+    const output = formatTable(
+      response([verse(1, 1, 'بسم الله'), verse(1, 2, 'الحمد لله')]),
+      'الله',
+    );
+
+    expect(output).toContain('1:1  بسم الله');
+    expect(output).toContain('1:2  الحمد لله');
+  });
+
+  it('reports the totals so the reader knows what is unseen', () => {
+    const output = formatTable(response([verse(2, 255, 'الله')], 313, 1, 20), 'الله');
+
+    expect(output).toContain('313');
+    expect(output).toMatch(/page 1 of 16/);
+  });
+
+  it('states there are no results rather than printing nothing', () => {
+    // Exit code 0 alone cannot distinguish "no matches" from a blank success, so the
+    // message has to be explicit.
+    const output = formatTable(response([], 0), 'زقفونة');
+
+    expect(output.trim()).toBe('No results for "زقفونة".');
+  });
+
+  it('uses the singular for a single result', () => {
+    expect(formatTable(response([verse(1, 1, 'بسم الله')], 1), 'بسم')).toMatch(/1 result\b/);
+  });
+
+  it('always ends with a newline', () => {
+    expect(formatTable(response([verse(1, 1, 'بسم')]), 'بسم').endsWith('\n')).toBe(true);
+    expect(formatTable(response([], 0), 'x').endsWith('\n')).toBe(true);
+  });
+});
+
+describe('formatResults', () => {
+  it('delegates json to the library exporter without decoration', () => {
+    const output = formatResults(response([verse(1, 1, 'بسم الله')]), 'json', 'بسم');
+    const parsed: unknown = JSON.parse(output);
+
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(output).not.toContain('Showing');
+  });
+
+  it('delegates csv to the library exporter, preserving its BOM and header', () => {
+    const output = formatResults(response([verse(1, 1, 'بسم الله')]), 'csv', 'بسم');
+
+    expect(output.startsWith('﻿')).toBe(true);
+    expect(output).toContain('sura,aya,score,matchType,text');
+  });
+
+  it('delegates tsv with tab separators', () => {
+    const output = formatResults(response([verse(1, 1, 'بسم الله')]), 'tsv', 'بسم');
+
+    expect(output).toContain('sura\taya\tscore\tmatchType\ttext');
+  });
+
+  it('renders the table when no machine format is requested', () => {
+    expect(formatResults(response([verse(1, 1, 'بسم الله')]), 'table', 'بسم')).toContain('1:1');
+  });
+});
+
+describe('helpText', () => {
+  it('lists every option with its default', () => {
+    const help = helpText();
+
+    for (const flag of [
+      '--lemma',
+      '--no-lemma',
+      '--root',
+      '--no-root',
+      '--fuzzy',
+      '--no-fuzzy',
+      '--semantic',
+      '--regex',
+      '--sura',
+      '--juz',
+      '--page',
+      '--limit',
+      '--format',
+      '--output',
+      '--help',
+      '--version',
+    ]) {
+      expect(help).toContain(flag);
+    }
+
+    expect(help).toMatch(/default: on/);
+    expect(help).toMatch(/default: off/);
+    expect(help).toMatch(/default: 1\b/);
+    expect(help).toMatch(/default: 20\b/);
+  });
+
+  it('says which query shapes need no flag', () => {
+    const help = helpText();
+
+    expect(help).toMatch(/2:255/);
+    expect(help).toMatch(/Logical operators/i);
+    expect(help).toMatch(/Transliteration/i);
+  });
+
+  it('documents the three exit codes', () => {
+    const help = helpText();
+
+    expect(help).toMatch(/0\s+completed/i);
+    expect(help).toMatch(/1\s+runtime error/i);
+    expect(help).toMatch(/2\s+invalid usage/i);
+  });
+});

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -147,6 +147,17 @@ describe('helpText', () => {
     expect(help).toMatch(/Transliteration/i);
   });
 
+  it('states the valid range for the scope filters', () => {
+    const help = helpText();
+
+    expect(help).toMatch(/--sura .*1 to 114/);
+    expect(help).toMatch(/--juz .*1 to 30/);
+  });
+
+  it('mentions that options accept --flag=value too', () => {
+    expect(helpText()).toMatch(/--limit=5/);
+  });
+
   it('documents the three exit codes', () => {
     const help = helpText();
 

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -1,0 +1,104 @@
+import type { QuranText, SearchResponse } from '../types';
+import { exportResults } from '../utils/export';
+import type { OutputFormat } from './args';
+
+/**
+ * The help screen. Every option lists its default, so the tool is self-describing
+ * without consulting the README.
+ */
+export const helpText = (): string =>
+  `quran-search-engine — search the Quran from the terminal
+
+Usage:
+  quran-search-engine <query> [options]
+
+Matching (defaults match the library's own defaults):
+  --lemma, --no-lemma      Word-family matching                    (default: on)
+  --root, --no-root        Word-root matching                      (default: on)
+  --fuzzy, --no-fuzzy      Approximate matching                    (default: on)
+  --semantic               Related-concept matching                (default: off)
+  --regex                  Treat the query as a pattern            (default: off)
+
+Scope:
+  --sura <n>               Restrict to one sura                    (default: all)
+  --juz <n>                Restrict to one juz                     (default: all)
+
+Results:
+  --page <n>               Which page of results                   (default: 1)
+  --limit <n>              Results per page                        (default: 20)
+
+Output:
+  --format <json|csv|tsv>  Machine-readable output       (default: readable table)
+  --output <file>          Write results to a file             (default: stdout)
+
+Other:
+  -h, --help               Show this help
+  --version                Show the installed version
+
+No flag is needed for these — they are recognised from the query itself:
+  Verse coordinates        "2:255", "1:1-7", "2:"
+  Logical operators        "الله AND (الرحمن OR الرحيم)", "الله NOT الرحمن"
+  Transliteration          "rahman" (single words; "bismi allah", not "bismillah")
+
+Examples:
+  quran-search-engine "رحم"
+  quran-search-engine "رحمة" --format json | jq .
+  quran-search-engine "الله" --page 3 --limit 50
+  quran-search-engine "رحم" --sura 2 --no-fuzzy
+  quran-search-engine "^.*ون$" --regex
+
+Exit codes:
+  0  completed (including when nothing matched)
+  1  runtime error (data could not be loaded, file could not be written)
+  2  invalid usage (unknown option, missing or blank query, bad value, unsafe pattern)
+
+Combining --regex with --lemma, --root, --fuzzy or --semantic prints a warning on stderr
+and continues: pattern matching runs on its own and ignores them.
+`;
+
+/**
+ * Renders results for a terminal reader: one line per verse, then the totals so the
+ * reader knows what they have not yet seen.
+ *
+ * @param response - The search response to render.
+ * @param query - The original query, quoted back in the no-results message.
+ * @returns A printable string, always newline-terminated.
+ */
+export const formatTable = (response: SearchResponse<QuranText>, query: string): string => {
+  const { results, pagination } = response;
+
+  if (results.length === 0) {
+    return `No results for "${query}".\n`;
+  }
+
+  const rows = results.map((verse) => `${verse.sura_id}:${verse.aya_id}  ${verse.standard}`);
+
+  const summary =
+    `\nShowing ${results.length} of ${pagination.totalResults} ` +
+    `${pagination.totalResults === 1 ? 'result' : 'results'} ` +
+    `(page ${pagination.currentPage} of ${pagination.totalPages})`;
+
+  return `${rows.join('\n')}\n${summary}\n`;
+};
+
+/**
+ * Picks the requested output shape. Machine-readable formats are delegated verbatim to
+ * the library's `exportResults`, so the CLI adds no serialisation of its own and its
+ * output stays identical to the library's.
+ *
+ * @param response - The search response to render.
+ * @param format - The requested output shape.
+ * @param query - The original query, used only by the table renderer.
+ * @returns A printable string.
+ */
+export const formatResults = (
+  response: SearchResponse<QuranText>,
+  format: OutputFormat,
+  query: string,
+): string => {
+  if (format === 'table') {
+    return formatTable(response, query);
+  }
+
+  return `${exportResults(response, format)}\n`;
+};

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -1,4 +1,4 @@
-import type { QuranText, SearchResponse } from '../types';
+import type { QuranText, SearchCounts, SearchResponse } from '../types';
 import { exportResults } from '../utils/export';
 import type { OutputFormat } from './args';
 
@@ -12,6 +12,8 @@ export const helpText = (): string =>
 Usage:
   quran-search-engine <query> [options]
 
+Options take their value either way: --limit 5 or --limit=5
+
 Matching (defaults match the library's own defaults):
   --lemma, --no-lemma      Word-family matching                    (default: on)
   --root, --no-root        Word-root matching                      (default: on)
@@ -20,8 +22,8 @@ Matching (defaults match the library's own defaults):
   --regex                  Treat the query as a pattern            (default: off)
 
 Scope:
-  --sura <n>               Restrict to one sura                    (default: all)
-  --juz <n>                Restrict to one juz                     (default: all)
+  --sura <n>               Restrict to one sura, 1 to 114          (default: all)
+  --juz <n>                Restrict to one juz, 1 to 30            (default: all)
 
 Results:
   --page <n>               Which page of results                   (default: 1)
@@ -57,6 +59,34 @@ and continues: pattern matching runs on its own and ignores them.
 `;
 
 /**
+ * Summarises which layers produced the matches, skipping the ones that produced none.
+ *
+ * `counts.simple` is reported as "exact" to match the `matchType` a reader sees, and
+ * `counts.fuzzy` covers both fuzzy and unscored matches, which is the library's own
+ * grouping. A range or regex query populates only its own field, so the zeros would be
+ * noise rather than information.
+ *
+ * @param counts - The counts block from the search response.
+ * @returns A one-line breakdown, or an empty string when there is nothing to report.
+ */
+const formatCounts = (counts: SearchCounts): string => {
+  const labelled: [string, number][] = [
+    ['exact', counts.simple],
+    ['lemma', counts.lemma],
+    ['root', counts.root],
+    ['fuzzy', counts.fuzzy],
+    ['semantic', counts.semantic],
+    ['regex', counts.regex],
+    ['range', counts.range],
+  ];
+
+  const present = labelled.filter(([, value]) => value > 0);
+  if (present.length === 0) return '';
+
+  return present.map(([label, value]) => `${label} ${value}`).join(' · ');
+};
+
+/**
  * Renders results for a terminal reader: one line per verse, then the totals so the
  * reader knows what they have not yet seen.
  *
@@ -78,7 +108,10 @@ export const formatTable = (response: SearchResponse<QuranText>, query: string):
     `${pagination.totalResults === 1 ? 'result' : 'results'} ` +
     `(page ${pagination.currentPage} of ${pagination.totalPages})`;
 
-  return `${rows.join('\n')}\n${summary}\n`;
+  const breakdown = formatCounts(response.counts);
+  const matches = breakdown === '' ? '' : `\nMatches: ${breakdown}`;
+
+  return `${rows.join('\n')}\n${summary}${matches}\n`;
 };
 
 /**

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from 'vitest';
+import type { MorphologyAya, QuranText, WordMap } from '../types';
+import { run, type CliDeps, type CliIo } from './run';
+
+/**
+ * A small fixture rather than the bundled corpus: the real data costs ~210 ms to load per
+ * call, and these tests are about the CLI's behavior, not the search engine's.
+ */
+const verse = (gid: number, sura: number, aya: number, standard: string, juz = 1): QuranText => ({
+  gid,
+  sura_id: sura,
+  aya_id: aya,
+  aya_id_display: String(aya),
+  uthmani: standard,
+  standard,
+  standard_full: standard,
+  page_id: 1,
+  juz_id: juz,
+  sura_name: 'الفاتحة',
+  sura_name_en: 'The Opening',
+  sura_name_romanization: 'Al-Fatihah',
+});
+
+// `الرحمن` deliberately appears in both suras and both juz values: a scope-filter test
+// against a term confined to one sura would pass even if no filtering happened at all.
+const FIXTURE: QuranText[] = [
+  verse(1, 1, 1, 'بسم الله الرحمن الرحيم'),
+  verse(2, 1, 2, 'الحمد لله رب العالمين'),
+  verse(3, 1, 3, 'الرحمن الرحيم'),
+  verse(4, 2, 1, 'ذلك الكتاب الرحمن لا ريب فيه', 2),
+  verse(5, 2, 2, 'هدى للمتقين الرحمن', 2),
+];
+
+const MORPHOLOGY: Map<number, MorphologyAya> = new Map(
+  FIXTURE.map((v) => [v.gid, { gid: v.gid, lemmas: [], roots: [] }]),
+);
+
+const testDeps = (overrides: CliDeps = {}): CliDeps => ({
+  loadQuranData: () => Promise.resolve(new Map(FIXTURE.map((v) => [v.gid, v]))),
+  loadMorphology: () => Promise.resolve(MORPHOLOGY),
+  loadWordMap: () => Promise.resolve(new Map() as WordMap),
+  loadSemanticData: () => Promise.resolve(new Map<string, string[]>()),
+  loadPhoneticData: () => Promise.resolve(new Map<string, string[]>()),
+  version: '9.9.9',
+  ...overrides,
+});
+
+/** Collects both streams so tests can assert on each independently. */
+const capture = (): { io: CliIo; out: () => string; err: () => string } => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    io: {
+      stdout: (text) => stdout.push(text),
+      stderr: (text) => stderr.push(text),
+    },
+    out: () => stdout.join(''),
+    err: () => stderr.join(''),
+  };
+};
+
+const invoke = async (
+  argv: string[],
+  overrides: CliDeps = {},
+): Promise<{ code: number; out: string; err: string }> => {
+  const { io, out, err } = capture();
+  const code = await run(argv, io, testDeps(overrides));
+  return { code, out: out(), err: err() };
+};
+
+describe('run', () => {
+  describe('exit code 0 — completed', () => {
+    it('finds matches and writes them to stdout', async () => {
+      const { code, out, err } = await invoke(['الرحمن']);
+
+      expect(code).toBe(0);
+      expect(out).toContain('1:1');
+      expect(err).toBe('');
+    });
+
+    it('reports no results as a success, explicitly', async () => {
+      const { code, out } = await invoke(['زقفونة']);
+
+      expect(code).toBe(0);
+      expect(out).toMatch(/no results/i);
+    });
+
+    it('treats a punctuation-only query as a search that matches nothing', async () => {
+      const { code, out } = await invoke(['!!!']);
+
+      expect(code).toBe(0);
+      expect(out).toMatch(/no results/i);
+    });
+
+    it('answers --help on stdout', async () => {
+      const { code, out } = await invoke(['--help']);
+
+      expect(code).toBe(0);
+      expect(out).toContain('--format');
+    });
+
+    it('reports the injected version, so it cannot drift from package.json', async () => {
+      const { code, out } = await invoke(['--version']);
+
+      expect(code).toBe(0);
+      expect(out.trim()).toBe('9.9.9');
+    });
+
+    it('resolves a range query without any flag', async () => {
+      const { code, out } = await invoke(['1:1-3']);
+
+      expect(code).toBe(0);
+      expect(out).toContain('1:1');
+      expect(out).toContain('1:3');
+    });
+  });
+
+  describe('exit code 2 — invalid usage', () => {
+    it('rejects a missing query on stderr', async () => {
+      const { code, out, err } = await invoke([]);
+
+      expect(code).toBe(2);
+      expect(err).toMatch(/query is required/i);
+      expect(out).toBe('');
+    });
+
+    it.each([
+      ['empty string', ''],
+      ['whitespace', '   '],
+    ])('rejects a blank query (%s)', async (_label, query) => {
+      const { code, err } = await invoke([query]);
+
+      expect(code).toBe(2);
+      expect(err).toMatch(/query is empty/i);
+    });
+
+    it('rejects an unknown flag', async () => {
+      const { code, err } = await invoke(['رحم', '--nonsense']);
+
+      expect(code).toBe(2);
+      expect(err).toContain('--nonsense');
+    });
+
+    it('rejects an unsupported format', async () => {
+      const { code, err } = await invoke(['رحم', '--format', 'yaml']);
+
+      expect(code).toBe(2);
+      expect(err).toContain('json');
+    });
+
+    it('rejects an invalid pattern promptly rather than hanging', async () => {
+      const { code, err } = await invoke(['(((', '--regex']);
+
+      expect(code).toBe(2);
+      expect(err).not.toBe('');
+    });
+  });
+
+  describe('exit code 1 — runtime fault', () => {
+    it('reports unloadable data', async () => {
+      const { code, out, err } = await invoke(['رحم'], {
+        loadQuranData: () => Promise.reject(new Error('quran.json is missing')),
+      });
+
+      expect(code).toBe(1);
+      expect(err).toMatch(/could not load/i);
+      expect(err).toContain('quran.json is missing');
+      expect(out).toBe('');
+    });
+
+    it('reports an unwritable output path as a runtime fault, not a usage error', async () => {
+      const { code, err } = await invoke(['الرحمن', '--output', '/nope/results.json'], {
+        writeFile: () => Promise.reject(new Error('ENOENT')),
+      });
+
+      expect(code).toBe(1);
+      expect(err).toMatch(/could not write/i);
+    });
+  });
+
+  describe('output formats', () => {
+    it('emits parseable json containing only data', async () => {
+      const { code, out } = await invoke(['الرحمن', '--format', 'json']);
+      const parsed: unknown = JSON.parse(out);
+
+      expect(code).toBe(0);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(out).not.toMatch(/showing/i);
+    });
+
+    it('emits csv with the library BOM and header', async () => {
+      const { out } = await invoke(['الرحمن', '--format', 'csv']);
+
+      expect(out.startsWith('﻿')).toBe(true);
+      expect(out).toContain('sura,aya,score,matchType,text');
+    });
+
+    it('emits tab-separated tsv', async () => {
+      const { out } = await invoke(['الرحمن', '--format', 'tsv']);
+
+      expect(out).toContain('sura\taya\tscore\tmatchType\ttext');
+    });
+  });
+
+  describe('--output', () => {
+    it('writes the chosen format to the file and leaves stdout empty', async () => {
+      const written: { path?: string; contents?: string } = {};
+
+      const { code, out } = await invoke(['الرحمن', '--format', 'csv', '--output', 'r.csv'], {
+        writeFile: (path, contents) => {
+          written.path = path;
+          written.contents = contents;
+          return Promise.resolve();
+        },
+      });
+
+      expect(code).toBe(0);
+      expect(out).toBe('');
+      expect(written.path).toBe('r.csv');
+      expect(written.contents).toContain('sura,aya,score,matchType,text');
+    });
+  });
+
+  describe('pagination', () => {
+    it('returns different verses per page with consistent totals', async () => {
+      const first = await invoke(['الرحمن', '--limit', '1', '--page', '1']);
+      const second = await invoke(['الرحمن', '--limit', '1', '--page', '2']);
+
+      expect(first.out).not.toBe(second.out);
+
+      const total = (text: string): string => text.match(/of (\d+) results?/)?.[1] ?? '';
+      expect(total(first.out)).toBe(total(second.out));
+    });
+
+    it('reports no results past the last page, still succeeding', async () => {
+      const { code, out } = await invoke(['الرحمن', '--page', '9999']);
+
+      expect(code).toBe(0);
+      expect(out).toMatch(/no results/i);
+    });
+  });
+
+  describe('scope filters', () => {
+    // `الرحمن` matches verses in both suras, so these assertions fail if filtering is skipped.
+    it('restricts results to one sura', async () => {
+      const { code, out } = await invoke(['الرحمن', '--sura', '2']);
+
+      expect(code).toBe(0);
+      expect(out).toMatch(/^2:/m);
+      expect(out).not.toMatch(/^1:/m);
+    });
+
+    it('restricts results to one juz', async () => {
+      const { code, out } = await invoke(['الرحمن', '--juz', '2']);
+
+      expect(code).toBe(0);
+      expect(out).toMatch(/^2:/m);
+      expect(out).not.toMatch(/^1:/m);
+    });
+
+    it('combines sura and juz filters', async () => {
+      // Sura 1 sits in juz 1, so asking for sura 1 within juz 2 can match nothing.
+      const { code, out } = await invoke(['الرحمن', '--sura', '1', '--juz', '2']);
+
+      expect(code).toBe(0);
+      expect(out).toMatch(/no results/i);
+    });
+
+    it('reports no results for an out-of-range sura instead of failing', async () => {
+      // An empty corpus would make search() throw MissingDependenciesError; the CLI answers
+      // directly instead, so this stays a successful run with nothing found.
+      const { code, out } = await invoke(['الرحمن', '--sura', '999']);
+
+      expect(code).toBe(0);
+      expect(out).toMatch(/no results/i);
+    });
+
+    it('counts totals within the scope, not across the whole corpus', async () => {
+      const all = await invoke(['الرحمن', '--limit', '1']);
+      const scoped = await invoke(['الرحمن', '--sura', '2', '--limit', '1']);
+
+      const total = (r: { out: string }): number =>
+        Number(r.out.match(/of (\d+) results?/)?.[1] ?? -1);
+      expect(total(all)).toBeGreaterThan(total(scoped));
+      expect(total(scoped)).toBe(2);
+    });
+  });
+
+  describe('warnings', () => {
+    it('warns that ignored options have no effect with --regex, then still succeeds', async () => {
+      const { code, out, err } = await invoke(['الرحمن', '--regex', '--lemma']);
+
+      expect(code).toBe(0);
+      expect(err).toMatch(/^Warning: /);
+      expect(err).toContain('--lemma');
+      expect(out).not.toBe('');
+    });
+  });
+
+  describe('stream discipline', () => {
+    it('keeps results on stdout and diagnostics on stderr', async () => {
+      const ok = await invoke(['الرحمن', '--format', 'json']);
+      expect(ok.err).toBe('');
+
+      const bad = await invoke(['رحم', '--nonsense']);
+      expect(bad.out).toBe('');
+    });
+  });
+});

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -266,10 +266,17 @@ describe('run', () => {
       expect(out).toMatch(/no results/i);
     });
 
-    it('reports no results for an out-of-range sura instead of failing', async () => {
-      // An empty corpus would make search() throw MissingDependenciesError; the CLI answers
-      // directly instead, so this stays a successful run with nothing found.
-      const { code, out } = await invoke(['الرحمن', '--sura', '999']);
+    it('rejects a sura number that does not exist', async () => {
+      const { code, err } = await invoke(['الرحمن', '--sura', '999']);
+
+      expect(code).toBe(2);
+      expect(err).toMatch(/1 to 114/);
+    });
+
+    it('still succeeds when an in-range scope simply holds nothing', async () => {
+      // Sura 1 sits in juz 1, so this combination is legal but empty. An empty corpus would
+      // make search() throw MissingDependenciesError, so the CLI answers directly instead.
+      const { code, out } = await invoke(['الرحمن', '--sura', '1', '--juz', '2']);
 
       expect(code).toBe(0);
       expect(out).toMatch(/no results/i);
@@ -283,6 +290,35 @@ describe('run', () => {
         Number(r.out.match(/of (\d+) results?/)?.[1] ?? -1);
       expect(total(all)).toBeGreaterThan(total(scoped));
       expect(total(scoped)).toBe(2);
+    });
+  });
+
+  describe('match breakdown in the table footer', () => {
+    it('reports which layers produced the matches', async () => {
+      const { out } = await invoke(['الرحمن']);
+
+      expect(out).toMatch(/Matches: /);
+      expect(out).toMatch(/exact \d+/);
+    });
+
+    it('names the range layer for a coordinate query, without the zeroes', async () => {
+      const { out } = await invoke(['1:1-3']);
+
+      expect(out).toContain('range 3');
+      expect(out).not.toContain('exact 0');
+      expect(out).not.toContain('lemma 0');
+    });
+
+    it('says nothing about matches when there are none', async () => {
+      const { out } = await invoke(['زقفونة']);
+
+      expect(out).not.toMatch(/Matches: /);
+    });
+
+    it('stays out of the machine-readable formats', async () => {
+      const { out } = await invoke(['الرحمن', '--format', 'json']);
+
+      expect(out).not.toMatch(/Matches: /);
     });
   });
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,0 +1,218 @@
+import { search } from '../core/search';
+import { InvalidPaginationError, InvalidQueryError, InvalidRegexError } from '../errors';
+import type {
+  AdvancedSearchOptions,
+  MorphologyAya,
+  PaginationOptions,
+  QuranText,
+  SearchContext,
+  SearchResponse,
+  WordMap,
+} from '../types';
+import {
+  loadMorphology,
+  loadPhoneticData,
+  loadQuranData,
+  loadSemanticData,
+  loadWordMap,
+} from '../utils/loader';
+import { isArabic } from '../utils/normalization';
+import { validateRegex } from '../utils/regex-validation';
+import { isUsageError, parseArgs } from './args';
+import { formatResults, helpText } from './format';
+
+/** Replaced at build time by tsup `define`; falls back for direct source execution. */
+declare const __CLI_VERSION__: string;
+
+/** Where the command writes. Injected so tests need no process mocking. */
+export type CliIo = {
+  stdout: (text: string) => void;
+  stderr: (text: string) => void;
+};
+
+/**
+ * Seams for testing. Every field defaults to the real implementation, so production
+ * callers pass nothing.
+ */
+export type CliDeps = {
+  loadQuranData?: () => Promise<Map<number, QuranText>>;
+  loadMorphology?: () => Promise<Map<number, MorphologyAya>>;
+  loadWordMap?: () => Promise<WordMap>;
+  loadSemanticData?: () => Promise<Map<string, string[]>>;
+  loadPhoneticData?: () => Promise<Map<string, string[]>>;
+  writeFile?: (path: string, contents: string) => Promise<void>;
+  version?: string;
+};
+
+/** Exit codes. A usage mistake is distinct from a failure while doing the work. */
+const EXIT_SUCCESS = 0;
+const EXIT_RUNTIME_ERROR = 1;
+const EXIT_INVALID_USAGE = 2;
+
+const resolveVersion = (deps: CliDeps): string => {
+  if (deps.version !== undefined) return deps.version;
+  return typeof __CLI_VERSION__ === 'string' ? __CLI_VERSION__ : '0.0.0-dev';
+};
+
+const writeToFile = async (path: string, contents: string): Promise<void> => {
+  const { writeFile } = await import('node:fs/promises');
+  await writeFile(path, contents, 'utf8');
+};
+
+const describe = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+/**
+ * Narrows the corpus to the requested sura and juz before searching.
+ *
+ * `search()` accepts `suraId` and `juzId` but only honours them on its regex path — its
+ * linguistic path ignores them entirely (`filterVerses` is applied inside the regex branch
+ * of `src/core/search.ts` only). Scoping the input corpus rather than the results keeps the
+ * reported totals and page counts correct, which post-filtering would not.
+ *
+ * @param data - The full verse map.
+ * @param options - Parsed search options carrying the optional scope filters.
+ * @returns The same map when no filter applies, otherwise a narrowed copy.
+ */
+const scopeCorpus = (
+  data: Map<number, QuranText>,
+  options: AdvancedSearchOptions,
+): Map<number, QuranText> => {
+  const { suraId, juzId } = options;
+  if (suraId === undefined && juzId === undefined) return data;
+
+  const scoped = new Map<number, QuranText>();
+  for (const [gid, verse] of data) {
+    if (suraId !== undefined && verse.sura_id !== suraId) continue;
+    if (juzId !== undefined && verse.juz_id !== juzId) continue;
+    scoped.set(gid, verse);
+  }
+  return scoped;
+};
+
+/** An empty result set, for when a scope filter leaves no verses to search at all. */
+const emptyResponse = (pagination: PaginationOptions): SearchResponse<QuranText> => ({
+  results: [],
+  counts: { simple: 0, lemma: 0, root: 0, fuzzy: 0, range: 0, semantic: 0, regex: 0, total: 0 },
+  pagination: {
+    totalResults: 0,
+    totalPages: 0,
+    currentPage: pagination.page ?? 1,
+    limit: pagination.limit ?? 20,
+  },
+});
+
+/**
+ * Runs one search and returns the exit code. Never calls `process.exit`, so the whole
+ * command is testable without mocking process termination.
+ *
+ * @param argv - Arguments after the node binary and script path.
+ * @param io - Destinations for results (stdout) and diagnostics (stderr).
+ * @param deps - Optional overrides for data loading, file writing and version reporting.
+ * @returns 0 on success (including no results), 1 on runtime fault, 2 on invalid usage.
+ */
+export const run = async (argv: string[], io: CliIo, deps: CliDeps = {}): Promise<number> => {
+  const parsed = parseArgs(argv);
+
+  if (isUsageError(parsed)) {
+    io.stderr(`${parsed.message}\n`);
+    return EXIT_INVALID_USAGE;
+  }
+
+  if (parsed.mode === 'help') {
+    io.stdout(helpText());
+    return EXIT_SUCCESS;
+  }
+
+  if (parsed.mode === 'version') {
+    io.stdout(`${resolveVersion(deps)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  const { query, options, pagination, format, output, warnings } = parsed;
+
+  for (const warning of warnings) {
+    io.stderr(`Warning: ${warning}\n`);
+  }
+
+  // Validate the pattern before loading megabytes of data, so a bad pattern fails fast.
+  if (options.isRegex === true) {
+    try {
+      validateRegex(query);
+    } catch (error) {
+      io.stderr(
+        `${describe(error)}\nCheck the pattern, or drop --regex to search for these characters literally.\n`,
+      );
+      return EXIT_INVALID_USAGE;
+    }
+  }
+
+  let context: SearchContext<QuranText>;
+  try {
+    const [quranData, morphologyMap, wordMap] = await Promise.all([
+      (deps.loadQuranData ?? loadQuranData)(),
+      (deps.loadMorphology ?? loadMorphology)(),
+      (deps.loadWordMap ?? loadWordMap)(),
+    ]);
+
+    // Load the optional datasets only when this query can actually use them: semantic
+    // data under --semantic, phonetic data only for non-Arabic input.
+    const semanticMap =
+      options.semantic === true ? await (deps.loadSemanticData ?? loadSemanticData)() : undefined;
+    const phoneticMap = isArabic(query)
+      ? undefined
+      : await (deps.loadPhoneticData ?? loadPhoneticData)();
+
+    context = {
+      quranData: scopeCorpus(quranData, options),
+      morphologyMap,
+      wordMap,
+      semanticMap,
+      phoneticMap,
+    };
+  } catch (error) {
+    io.stderr(
+      `Could not load the Quran data: ${describe(error)}\nThe installed package may be incomplete — try reinstalling quran-search-engine.\n`,
+    );
+    return EXIT_RUNTIME_ERROR;
+  }
+
+  let rendered: string;
+  try {
+    // A scope filter can legitimately leave nothing to search — an out-of-range --sura, say.
+    // search() treats an empty corpus as a missing dependency and throws, so answer directly.
+    const response =
+      context.quranData.size === 0
+        ? emptyResponse(pagination)
+        : search(query, context, options, pagination);
+    rendered = formatResults(response, format, query);
+  } catch (error) {
+    // These three mean the input was unacceptable, not that the run broke.
+    if (
+      error instanceof InvalidQueryError ||
+      error instanceof InvalidPaginationError ||
+      error instanceof InvalidRegexError
+    ) {
+      io.stderr(`${describe(error)}\n`);
+      return EXIT_INVALID_USAGE;
+    }
+
+    io.stderr(`Search failed: ${describe(error)}\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
+  if (output !== undefined) {
+    try {
+      await (deps.writeFile ?? writeToFile)(output, rendered);
+    } catch (error) {
+      io.stderr(
+        `Could not write to "${output}": ${describe(error)}\nCheck that the directory exists and is writable.\n`,
+      );
+      return EXIT_RUNTIME_ERROR;
+    }
+    return EXIT_SUCCESS;
+  }
+
+  io.stdout(rendered);
+  return EXIT_SUCCESS;
+};

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -6,6 +6,7 @@ import type {
   PaginationOptions,
   QuranText,
   SearchContext,
+  SearchCounts,
   SearchResponse,
   WordMap,
 } from '../types';
@@ -90,10 +91,21 @@ const scopeCorpus = (
   return scoped;
 };
 
+const NO_COUNTS: SearchCounts = {
+  simple: 0,
+  lemma: 0,
+  root: 0,
+  fuzzy: 0,
+  range: 0,
+  semantic: 0,
+  regex: 0,
+  total: 0,
+};
+
 /** An empty result set, for when a scope filter leaves no verses to search at all. */
 const emptyResponse = (pagination: PaginationOptions): SearchResponse<QuranText> => ({
   results: [],
-  counts: { simple: 0, lemma: 0, root: 0, fuzzy: 0, range: 0, semantic: 0, regex: 0, total: 0 },
+  counts: NO_COUNTS,
   pagination: {
     totalResults: 0,
     totalPages: 0,

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -294,6 +294,9 @@ export const search = <TVerse extends VerseInput>(
     simple: combined.filter((v) => v.matchType === 'exact').length,
     lemma: combined.filter((v) => v.matchType === 'lemma').length,
     root: combined.filter((v) => v.matchType === 'root').length,
+    // BUG: `fuzzy` also counts verses whose matchType is 'none', so it over-reports fuzzy
+    // matches and no field reports unscored ones. Consumers displaying a per-type breakdown
+    // (the CLI does) therefore attribute 'none' results to fuzzy matching. Tracked in #102.
     fuzzy: combined.filter((v) => v.matchType === 'none' || v.matchType === 'fuzzy').length,
     semantic: combined.filter((v) => v.matchType === 'semantic').length,
     regex: 0,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,11 +1,29 @@
 import { defineConfig } from 'tsup';
+import { version } from './package.json';
 
-export default defineConfig({
-  entry: ['src/index.ts', 'src/worker/search-worker.ts'],
-  format: ['cjs', 'esm'],
-  dts: true,
-  clean: true,
-  splitting: false,
-  sourcemap: true,
-  minify: false,
-});
+export default defineConfig([
+  {
+    entry: ['src/index.ts', 'src/worker/search-worker.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    clean: true,
+    splitting: false,
+    sourcemap: true,
+    minify: false,
+  },
+  {
+    // The CLI is built separately so the shebang banner lands only on the executable,
+    // never on the library or worker entries.
+    entry: ['src/cli.ts'],
+    format: ['cjs'],
+    dts: false,
+    clean: false,
+    splitting: false,
+    sourcemap: true,
+    minify: false,
+    banner: { js: '#!/usr/bin/env node' },
+    // Injected at build time so the reported version cannot drift from package.json, and
+    // so nothing has to resolve a relative path to it at runtime.
+    define: { __CLI_VERSION__: JSON.stringify(version) },
+  },
+]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11477,6 +11477,8 @@ __metadata:
     typescript: "npm:^5.0.0"
     typescript-eslint: "npm:^8.57.0"
     vitest: "npm:^1.0.0"
+  bin:
+    quran-search-engine: ./dist/cli.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Adds a `quran-search-engine` bin so the engine can be used from a terminal, and piped into
other tools, without writing any code. The CLI is a thin wrapper over the existing API. It
parses flags into the shapes `search()` already takes, calls it once, and formats the
result. No matching logic lives in the CLI.

Implements the option surface we agreed on in the issue: independent boolean toggles instead
of a single `--type`, `--page` alongside `--limit`, and separate exit codes for "no results"
and "error".

## Linked issues

Fixes #93

## What it looks like

```bash
npx quran-search-engine "رحم"
quran-search-engine "رحمة" --format json | jq .
quran-search-engine "الله" --sura 1 --page 2 --limit 5
quran-search-engine "2:255"                 # verse coordinates, no flag needed
quran-search-engine "الله NOT الرحمن"        # boolean operators, no flag needed
```

Flags map straight onto `AdvancedSearchOptions` and keep the library defaults (lemma, root
and fuzzy on, semantic and regex off, page 1, limit 20), so terminal results match what the
library returns for the same query. I checked this rather than assuming it: CLI
`--format json` output is byte-identical to calling `search()` directly with the same
arguments.

Exit codes follow what you specified. 0 means it completed, including when nothing matched.
1 is a runtime error, data that would not load or a file that would not write. 2 is invalid
usage, an unknown option or a bad value.

Boolean operators, verse ranges and Latin transliteration all work with no flag, since
`search()` already picks those up from the query itself.

## Files

```
src/cli.ts          entry point, the only file that touches process
src/cli/args.ts     pure parser, argv in, typed options or a usage error out
src/cli/run.ts      loads data, calls search(), writes output, returns an exit code
src/cli/format.ts   help screen, verse table, delegates json/csv/tsv to exportResults
```

Plus tests beside each, the tsup entry, the `bin` field, README and CHANGELOG.

`run()` returns a number instead of calling `process.exit`, and takes its loaders as
optional dependencies. That is what lets the tests cover all three exit codes and the
data-load failure without mocking process internals, and it keeps them fast: the CLI suite
runs in about 150 ms against a small fixture rather than loading the real corpus each time.

## Three things I would like your call on

**`exportResults` was already on `develop`.** Your comment asked me to add it as part of this
work, but #96 merged it before I started, so I have consumed it rather than writing it again.
Nothing in this PR touches `src/utils/export.ts`.

**Sura and juz filters, and a library gap behind them.** `search()` only applies `suraId` and
`juzId` on its regex path. `filterVerses` is called inside the regex branch of
`src/core/search.ts` and nowhere else, so on the normal linguistic path both options are
ignored: searching `الله` with `suraId: 1` returns verses from sura 2 onward. I have worked
around it in the CLI by narrowing the corpus before the search rather than filtering results
afterwards, which keeps the reported totals and page counts correct. I have deliberately not
touched the library, since that behaviour affects every consumer and deserves its own issue
and review. Happy to open one, or to fold the fix in here if you would rather.

**The inverted index is not built.** Your comment said to reuse it where applicable, and I
measured it before deciding: building it costs 245 ms and then the search takes 36 ms, so
281 ms in total, against 253 ms searching without it. For a single query per process it does
not pay for itself, and it costs memory on top. Both paths return identical results, 313
matches for `رحم`. It would be worth having again if a batch or interactive mode ever lands.

## Notes on two things I found along the way

Piping large output was silently truncating at 65,536 bytes, because calling `process.exit()`
throws away anything still queued past the pipe buffer. `src/cli.ts` sets `process.exitCode`
instead and lets the process finish on its own. Piping now returns the same 128,305 bytes
that redirecting to a file does.

Transliteration examples in the new docs use single words. `bismillah` as one token matches
nothing, because the phonetic map is keyed per word. `bismi`, `rahman` and `bismi allah` all
work. The existing line further down the README saying `search('Bismillah')` finds verse 1 is
wrong, but I have left it alone here rather than widen this PR.

## Branch

- [x] Branched from `develop` (the default base)
- [x] No merge commits; rebased onto current `develop` HEAD

## Pre-PR quality gate (run in order; all must pass)

- [x] `yarn lint` exits 0, no warnings
- [x] `yarn build` produces `dist/`, including an executable `dist/cli.js`
- [x] `yarn test` green on CI
- [x] `yarn size-limit` 1.19 MB of 2 MB
- [ ] `yarn lint:md` (see below)

I ran this PR through CI on my own fork first and all of it is green there:
MalikMlitat/quran-search-engine#1.

Two pre-existing issues in the gate, neither of which I have touched:

1. `yarn test` passes on CI but fails locally for me, in `src/utils/loader.test.ts > should
   throw an error if JSON files are corrupted`. It copies about 8.6 MB of data files and then
   calls `loadMorphology(path)`, `loadQuranData(path)` and `loadWordMap(path)`. None of those
   three take a parameter, so the paths are ignored and the test loads the real corpus instead
   of the corrupted copies it just wrote, which also means it is not testing what its name
   says. It takes about 6.8 seconds against a 5 second timeout and fails 4 out of 4 runs on
   clean `develop`. CI has fewer cores, so vitest runs fewer files at once and it stays under
   the limit there. Glad to open an issue.
2. `yarn lint:md` runs out of memory. The ignore list only covers the top-level
   `node_modules`, so once the example workspaces are installed it tries to lint 1,862
   markdown files under `examples/*/node_modules` alongside the 194 real ones. Linting the
   real files directly is clean. Also happy to open an issue for that.

One thing CI caught that I could not have locally: `yarn install --immutable` failed at first
because Yarn Berry keeps a workspace's own `bin` field in `yarn.lock`, and I had not
regenerated the lockfile. Plain `yarn install` fixes it silently, so it only showed up under
`--immutable`. The regenerated lockfile is committed with the `package.json` change, and I
kept the `bin` field in the string shorthand yarn rewrites it to.

## AI-assisted code

- [x] I built and tested the change locally before pushing
- [x] I re-read the diff and removed dead or speculative code
- [x] I added or updated tests for every behavior change
- [x] I can explain every line I am submitting

## User-visible changes

- [x] `CHANGELOG.md` updated under `[Unreleased]` / `Added`

No clip attached, the output is plain text and the examples above show it.

## Docs

- [x] README has a new `## CLI` section covering install, every flag with its default, the
      exit codes, output formats, piping, and which query shapes need no flag. It also notes
      that custom data loading, `--quran` and `--data-dir`, is out of scope and can be a
      separate issue as you suggested.

## Checklist

- [x] One logical change in this PR
- [x] Commit messages follow Conventional Commits (enforced via commitlint)
- [x] PR title is a complete Conventional Commit subject (≤ 72 chars)

## Tests

82 tests across three files. `args.test.ts` covers parsing, the defaults and every rejection.
`format.test.ts` covers the table, the help screen and format delegation. `run.test.ts`
covers all three exit codes, the output formats, `--output`, pagination, the scope filters,
warnings and stream separation.

The scope filter tests are worth a glance. The fixture puts `الرحمن` in both suras and both
juz values on purpose. My first version had the search term in one sura only, which meant the
test passed even when no filtering happened at all, and that is precisely how the library gap
above stayed hidden from me for a while. I checked that all five scope tests fail when the
filter is switched off.
