### PR TITLE
build(lint): ignore nested node_modules in lint:md

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "vitest",
     "lint": "npx eslint . --cache --max-warnings=0",
     "lint:fix": "npx eslint . --fix --cache",
-    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.agent\"",
+    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules\" \"#.agent\"",
     "docs:start": "cd docs && npx fumapress",
     "format": "prettier --write .",
     "prepare": "husky",


### PR DESCRIPTION
Fixes #99

## Problem

The `lint:md` ignore pattern `#node_modules` only matches the top-level directory. After a workspace-root `yarn install`, the `**/*.md` glob therefore also walks `examples/*/node_modules`:

```
markdown files under any node_modules: 1862
markdown files in the project itself:   193
```

Node then dies after roughly 260 seconds with `FATAL ERROR: Ineffective mark-compacts near heap limit — JavaScript heap out of memory`, so step 2 of the pre-PR quality gate in CONTRIBUTING cannot pass locally.

## Change

One line — use `#**/node_modules` so nested workspace installs are excluded too.

## Verification

`yarn lint:md` now completes in ~2.2s instead of OOM-ing after ~260s.

## Note — the gate still fails, for an unrelated reason

With the OOM out of the way, `lint:md` surfaces pre-existing violations in tracked files (mostly MD013 line-length, plus a corrupted encoding in `src/errors/README.md`).

These are not caused by this change: `npx markdownlint-cli2 "README.md"` fails identically on unmodified `develop`. CI only runs `yarn lint` (eslint) and never `lint:md`, which is why they went unnoticed. Left out of scope here — follow-up in a separate PR.
