### PR TITLE
fix(search): count only genuine fuzzy matches in counts.fuzzy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Search counts**: `counts.fuzzy` no longer includes unscored matches (`matchType: 'none'`) —
+  it counts genuine fuzzy matches only, in both `search()` and multi-term search. Unscored
+  matches are still reported in `counts.total`. The per-type breakdown in the CLI footer
+  inherits the corrected grouping.
+
 ### Added
 
 - **CLI**: New `quran-search-engine` command for searching the Quran from a terminal, runnable via

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -62,8 +62,9 @@ and continues: pattern matching runs on its own and ignores them.
  * Summarises which layers produced the matches, skipping the ones that produced none.
  *
  * `counts.simple` is reported as "exact" to match the `matchType` a reader sees, and
- * `counts.fuzzy` covers both fuzzy and unscored matches, which is the library's own
- * grouping. A range or regex query populates only its own field, so the zeros would be
+ * `counts.fuzzy` reports genuine fuzzy matches only — unscored matches, if any,
+ * are counted in the totals but not attributed to any layer (see `SearchCounts`).
+ * A range or regex query populates only its own field, so the zeros would be
  * noise rather than information.
  *
  * @param counts - The counts block from the search response.

--- a/src/core/layers/search-many.ts
+++ b/src/core/layers/search-many.ts
@@ -1,6 +1,7 @@
 import type Fuse from 'fuse.js';
 import type { LRUCache } from '../../utils/lru-cache';
 import { InvalidPaginationError } from '../../errors';
+import { buildSearchCounts } from '../../utils/search-counts';
 import type {
   AdvancedSearchOptions,
   MergedSearchResult,
@@ -142,20 +143,11 @@ export const searchManyImpl = <TVerse extends VerseInput>(
   const totalResults = mergedResults.length;
   const totalPages = Math.ceil(totalResults / limit);
 
-  const counts: SearchCounts = {
-    simple: mergedResults.filter((v) => v.matchType === 'exact').length,
-    lemma: mergedResults.filter((v) => v.matchType === 'lemma').length,
-    root: mergedResults.filter((v) => v.matchType === 'root').length,
-    fuzzy: mergedResults.filter((v) => v.matchType === 'none' || v.matchType === 'fuzzy').length,
-    semantic: mergedResults.filter((v) => v.matchType === 'semantic').length,
-    // Unlike search()'s own counts (reached only after range/regex short-circuit,
-    // so those matchTypes can never appear there), mergedResults comes from N
-    // independent per-term search() calls — any one of them could have taken the
-    // range/regex early-return path, so those matchTypes genuinely can show up here.
-    regex: mergedResults.filter((v) => v.matchType === 'regex').length,
-    range: mergedResults.filter((v) => v.matchType === 'range').length,
-    total: mergedResults.length,
-  };
+  // Unlike search()'s own counts (reached only after range/regex short-circuit,
+  // so those matchTypes can never appear there), mergedResults comes from N
+  // independent per-term search() calls — any one of them could have taken the
+  // range/regex early-return path, so those matchTypes genuinely can show up here.
+  const counts: SearchCounts = buildSearchCounts(mergedResults);
 
   return {
     results,

--- a/src/core/search.test.ts
+++ b/src/core/search.test.ts
@@ -169,4 +169,16 @@ describe('Search Orchestrator (Integration)', () => {
     expect(result.results.length).toBeLessThanOrEqual(limit);
     expect(result.pagination.limit).toBe(limit);
   });
+
+  it('should keep counts.fuzzy consistent with the actual fuzzy results (refs #102)', () => {
+    const result = search('الله', {
+      quranData: mockQuranDataMap,
+      morphologyMap: mockMorphologyMap,
+      wordMap: mockWordMapMap,
+    });
+    const fuzzyResults = result.results.filter((v) => v.matchType === 'fuzzy');
+    const exactResults = result.results.filter((v) => v.matchType === 'exact');
+    expect(result.counts.fuzzy).toBe(fuzzyResults.length);
+    expect(result.counts.simple).toBe(exactResults.length);
+  });
 });

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -12,6 +12,7 @@ import { performAdvancedLinguisticSearch } from './layers/linguistic-search';
 import { performSemanticSearch } from './layers/semantic-search';
 import { searchManyImpl } from './layers/search-many';
 import { computeScore } from '../utils/scoring';
+import { buildSearchCounts } from '../utils/search-counts';
 
 import type {
   AdvancedSearchOptions,
@@ -326,19 +327,7 @@ export function search<TVerse extends VerseInput>(
   const totalResults = combined.length;
   const totalPages = Math.ceil(totalResults / limit);
 
-  const counts: SearchCounts = {
-    simple: combined.filter((v) => v.matchType === 'exact').length,
-    lemma: combined.filter((v) => v.matchType === 'lemma').length,
-    root: combined.filter((v) => v.matchType === 'root').length,
-    // BUG: `fuzzy` also counts verses whose matchType is 'none', so it over-reports fuzzy
-    // matches and no field reports unscored ones. Consumers displaying a per-type breakdown
-    // (the CLI does) therefore attribute 'none' results to fuzzy matching. Tracked in #102.
-    fuzzy: combined.filter((v) => v.matchType === 'none' || v.matchType === 'fuzzy').length,
-    semantic: combined.filter((v) => v.matchType === 'semantic').length,
-    regex: 0,
-    range: 0,
-    total: combined.length,
-  };
+  const counts: SearchCounts = buildSearchCounts(combined);
 
   const response: SearchResponse<TVerse> = {
     results,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,15 @@ export type AdvancedSearchOptions = {
 
 export type SearchOptions = AdvancedSearchOptions;
 
+/**
+ * Per-layer match counts for a search response.
+ *
+ * Each field counts verses whose `matchType` equals the corresponding layer
+ * (`simple` counts `'exact'`). `fuzzy` counts only genuine fuzzy matches:
+ * verses that reached the result set without any layer claiming them
+ * (`matchType: 'none'`) appear in `total` only, so the per-type fields do not
+ * necessarily sum to `total`.
+ */
 export type SearchCounts = {
   simple: number;
   lemma: number;

--- a/src/utils/search-counts.test.ts
+++ b/src/utils/search-counts.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { buildSearchCounts } from './search-counts';
+import type { MatchType } from '../types';
+
+const verse = (matchType: MatchType) => ({ matchType });
+
+describe('buildSearchCounts', () => {
+  it('counts only genuine fuzzy matches in fuzzy (refs #102)', () => {
+    const counts = buildSearchCounts([
+      verse('exact'),
+      verse('exact'),
+      verse('fuzzy'),
+      verse('none'),
+      verse('none'),
+    ]);
+
+    expect(counts.simple).toBe(2);
+    expect(counts.fuzzy).toBe(1);
+    expect(counts.total).toBe(5);
+  });
+
+  it('reports unscored matches in total only', () => {
+    const counts = buildSearchCounts([verse('none'), verse('lemma'), verse('root')]);
+
+    expect(counts.lemma).toBe(1);
+    expect(counts.root).toBe(1);
+    expect(counts.fuzzy).toBe(0);
+    expect(counts.total).toBe(3);
+  });
+
+  it('tallies every layer including regex and range', () => {
+    const counts = buildSearchCounts([
+      verse('exact'),
+      verse('lemma'),
+      verse('root'),
+      verse('fuzzy'),
+      verse('semantic'),
+      verse('regex'),
+      verse('range'),
+    ]);
+
+    expect(counts).toEqual({
+      simple: 1,
+      lemma: 1,
+      root: 1,
+      fuzzy: 1,
+      semantic: 1,
+      regex: 1,
+      range: 1,
+      total: 7,
+    });
+  });
+
+  it('returns zeros for an empty result set', () => {
+    expect(buildSearchCounts([])).toEqual({
+      simple: 0,
+      lemma: 0,
+      root: 0,
+      fuzzy: 0,
+      semantic: 0,
+      regex: 0,
+      range: 0,
+      total: 0,
+    });
+  });
+});

--- a/src/utils/search-counts.ts
+++ b/src/utils/search-counts.ts
@@ -1,0 +1,28 @@
+import type { MatchType, SearchCounts } from '../types';
+
+/**
+ * Tallies per-layer match counts over a fully scored result set.
+ *
+ * `fuzzy` counts only verses whose `matchType` is `'fuzzy'`. Verses that
+ * reached the result set without any layer claiming them (`matchType: 'none'`)
+ * are reported in `total` only, so the per-type fields intentionally do not
+ * sum to `total` when unscored matches are present.
+ *
+ * Shared by `search()` and the multi-term merger so both report the same
+ * grouping (see #102).
+ *
+ * @param scored - The complete, deduplicated result set before pagination.
+ * @returns Per-type counts plus the overall total.
+ */
+export const buildSearchCounts = <T extends { matchType: MatchType }>(
+  scored: readonly T[],
+): SearchCounts => ({
+  simple: scored.filter((v) => v.matchType === 'exact').length,
+  lemma: scored.filter((v) => v.matchType === 'lemma').length,
+  root: scored.filter((v) => v.matchType === 'root').length,
+  fuzzy: scored.filter((v) => v.matchType === 'fuzzy').length,
+  semantic: scored.filter((v) => v.matchType === 'semantic').length,
+  regex: scored.filter((v) => v.matchType === 'regex').length,
+  range: scored.filter((v) => v.matchType === 'range').length,
+  total: scored.length,
+});


### PR DESCRIPTION
# Pull Request

## Summary

`counts.fuzzy` counted unscored matches (`matchType: 'none'`) as fuzzy matches, over-reporting
fuzzy matching and making unscored results invisible in per-type breakdowns (e.g. the CLI footer).
This PR counts only genuine `'fuzzy'` matches, via a shared `buildSearchCounts()` helper used by
both `search()` and the multi-term merger, and documents the field meaning on `SearchCounts`.

## Linked issues

Fixes #102

## Branch

- [x] Branched from `develop` (the default base)
- [x] No merge commits; rebased onto current `develop` HEAD

## Pre-PR quality gate (run in order; all must pass)

- [x] `yarn lint` - exits 0, no warnings
- [x] `yarn lint:md` - markdownlint clean
- [x] `yarn build` - tsup produces `dist/`
- [x] `yarn test` - vitest green, except one pre-existing failure (see note)
- [x] `yarn size-limit` - `dist/index.mjs` under 2 MB (1.19 MB brotlied, unchanged)

Note: `src/utils/loader.test.ts > should throw an error if JSON files are corrupted` times out
locally. That is the known issue #98 (fails on clean `develop` the same way — the test copies
~8.6 MB and loads the real corpus instead of the corrupted copies while the loaders ignore the
passed paths). It is unrelated to this change, which touches no loader code.

## AI-assisted code

- [x] I built and tested the change locally before pushing
- [x] I re-read the diff and removed dead or speculative code
- [x] I added or updated tests for every behavior change
- [x] I can explain every line I am submitting

## User-visible changes

- [x] `CHANGELOG.md` updated under `[Unreleased]` using Keep-a-Changelog categories (`Fixed`)

The CLI per-type footer now reports genuine fuzzy counts; no UI change otherwise.

## Docs

- [x] No `docs/` guide change needed: the behavior is documented via JSDoc on `SearchCounts`
  and `buildSearchCounts()`, plus the `formatCounts` comment. No public API shape changed
  (option 2 from the issue — `SearchCounts` keeps its fields).

## Checklist

- [x] One logical change in this PR
- [x] Commit messages follow Conventional Commits (enforced via commitlint)
- [x] PR title is a complete Conventional Commit subject (<= 72 chars)
