### PR TITLE
test(loader): make corrupted-JSON test meaningful and fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Loader corrupted-JSON test**: rewrote the test to simulate corrupted data files by mocking
+  the data modules instead of copying ~8.6 MB of real data (the loaders ignore file-path
+  arguments by design — they use static bundler-analyzable JSON imports). The test now asserts
+  `DataParseError`/`DataSchemaInvalidError` precisely and runs in milliseconds instead of
+  timing out.
+
 ### Added
 
 - **CLI**: New `quran-search-engine` command for searching the Quran from a terminal, runnable via

--- a/src/utils/loader.test.ts
+++ b/src/utils/loader.test.ts
@@ -1,44 +1,56 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { loadQuranData, loadMorphology, loadWordMap, buildInvertedIndex } from './loader';
 import type { QuranText, MorphologyAya } from '../types';
 import fs from 'fs';
 
 describe('Loader Functions', () => {
-  // Add test case for corrupted/invalid JSON data
+  // Regression test for #98: the old version copied ~8.6 MB of real data, passed paths
+  // the loaders ignore, asserted success, and timed out. The loaders intentionally use
+  // static bundler-analyzable JSON imports (see loader.ts), so corrupted files are
+  // simulated by mocking the data modules instead — fast and hermetic.
   it('should throw an error if JSON files are corrupted', async () => {
-    // Temporarily rename the morphology.json file to simulate corrupted file
-    const morphologyOriginalPath = __dirname + '/../data/morphology.json';
-    const quranDataOriginalPath = __dirname + '/../data/quran.json';
-    const wordMapOriginalPath = __dirname + '/../data/word-map.json';
-    const morphologyBackupPath = morphologyOriginalPath + '.backup';
-    const quranDataBackupPath = quranDataOriginalPath + '.backup';
-    const wordMapBackupPath = wordMapOriginalPath + '.backup';
+    vi.resetModules();
+    vi.doMock('../data/morphology.json', () => {
+      throw new SyntaxError(`"This is not valid JSON" is not valid JSON`);
+    });
+    vi.doMock('../data/quran.json', () => {
+      throw new SyntaxError(`"This is not valid JSON" is not valid JSON`);
+    });
+    vi.doMock('../data/word-map.json', () => {
+      throw new SyntaxError(`"This is not valid JSON" is not valid JSON`);
+    });
 
     try {
-      // Backup the original file
-      await fs.promises.copyFile(morphologyOriginalPath, morphologyBackupPath);
-      await fs.promises.copyFile(quranDataOriginalPath, quranDataBackupPath);
-      await fs.promises.copyFile(wordMapOriginalPath, wordMapBackupPath);
+      // NOTE: both modules are imported dynamically *after* resetModules so the
+      // error classes share a module realm with the loader under test —
+      // otherwise `instanceof` fails across the two module instances.
+      const freshLoader = await import('./loader');
+      const freshErrors = await import('../errors');
 
-      // Write invalid JSON to the backup file
-      await fs.promises.writeFile(morphologyBackupPath, 'This is not valid JSON');
-      await fs.promises.writeFile(quranDataBackupPath, 'This is not valid JSON');
-      await fs.promises.writeFile(wordMapBackupPath, 'This is not valid JSON');
-
-      const morphology = await loadMorphology(morphologyBackupPath);
-      const quranData = await loadQuranData(quranDataBackupPath);
-      const wordMap = await loadWordMap(wordMapBackupPath);
-
-      expect(morphology).toBeInstanceOf(Map);
-      expect(quranData).toBeInstanceOf(Array);
-      expect(wordMap).toBeInstanceOf(Object);
-    } catch (error: unknown) {
-      expect(error).toBeInstanceOf(Error);
+      await expect(freshLoader.loadMorphology()).rejects.toThrow(freshErrors.DataParseError);
+      await expect(freshLoader.loadQuranData()).rejects.toThrow(freshErrors.DataParseError);
+      await expect(freshLoader.loadWordMap()).rejects.toThrow(freshErrors.DataParseError);
     } finally {
-      // Delete the corrupted file
-      await fs.promises.unlink(morphologyBackupPath);
-      await fs.promises.unlink(quranDataBackupPath);
-      await fs.promises.unlink(wordMapBackupPath);
+      vi.doUnmock('../data/morphology.json');
+      vi.doUnmock('../data/quran.json');
+      vi.doUnmock('../data/word-map.json');
+      vi.resetModules();
+    }
+  });
+
+  it('should throw a schema error if JSON files have an unexpected shape', async () => {
+    vi.resetModules();
+    vi.doMock('../data/quran.json', () => ({ default: { not: 'an array' } }));
+
+    try {
+      // Same module-realm note as above: import both dynamically after resetModules.
+      const freshLoader = await import('./loader');
+      const freshErrors = await import('../errors');
+
+      await expect(freshLoader.loadQuranData()).rejects.toThrow(freshErrors.DataSchemaInvalidError);
+    } finally {
+      vi.doUnmock('../data/quran.json');
+      vi.resetModules();
     }
   });
 


### PR DESCRIPTION
# Pull Request

## Summary

Rewrites the `loader.test.ts > should throw an error if JSON files are corrupted` test, which
neither tested what its name says nor passed reliably: it copied ~8.6 MB of real data, passed
paths the loaders ignore, asserted success, and timed out against vitest's 5 s default. The test
now simulates corrupted data files by mocking the JSON modules, asserts `DataParseError`
precisely (plus a new `DataSchemaInvalidError` shape case), and runs in milliseconds.

## Linked issues

Fixes #98

## Branch

- [x] Branched from `develop` (the default base)
- [x] No merge commits; rebased onto current `develop` HEAD

## Pre-PR quality gate (run in order; all must pass)

- [x] `yarn lint` - exits 0, no warnings
- [x] `yarn lint:md` - markdownlint clean
- [x] `yarn build` - tsup produces `dist/`
- [x] `yarn test` - vitest green (27 files, 377 tests, full suite)
- [x] `yarn size-limit` - `dist/index.mjs` under 2 MB (1.19 MB brotlied, unchanged — test-only change)

## AI-assisted code

- [x] I built and tested the change locally before pushing
- [x] I re-read the diff and removed dead or speculative code
- [x] I added or updated tests for every behavior change (this PR *is* the test change)
- [x] I can explain every line I am submitting

## User-visible changes

- [x] `CHANGELOG.md` updated under `[Unreleased]` using Keep-a-Changelog categories (`Fixed`)

No library behavior changed — test-only PR.

## Docs

- [x] No `docs/` guide change needed. One design note for reviewers: the issue suggests giving
  the loaders an optional file-path parameter, but the loaders intentionally use static
  bundler-analyzable JSON imports (see the comment in `loader.ts`), and an `fs`-based custom
  path would break browser/bundler consumers. Mocking the data modules exercises the same
  error-mapping and validation paths without touching the public API or the bundle.

## Checklist

- [x] One logical change in this PR
- [x] Commit messages follow Conventional Commits (enforced via commitlint)
- [x] PR title is a complete Conventional Commit subject (<= 72 chars)
