### PR TITLE
fix: apply sura name filter to all combined results

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/adelpro/quran-search-engine",
+  "public_key": "pk_qiM4HEbnjUHZB7itJCMt0",
+  "projectTitle": "quran-search-engine",
+  "description": "Stateless, UI-agnostic Quran search engine for Arabic text in pure TypeScript, supporting exact, lemma/root, fuzzy, semantic, phonetic, boolean, regex, and range search",
+  "excludeFolders": [".agent", ".github", ".husky", "assets"],
+  "excludeFiles": ["CHANGELOG.md", "CODE_OF_CONDUCT.md", "SECURITY.md"],
+  "rules": [
+    "Import only from the package root (quran-search-engine); everything documented is re-exported from src/index.ts",
+    "search() requires quranData, morphologyMap, and wordMap loaded via loadQuranData(), loadMorphology(), loadWordMap() before calling",
+    "For lemma/root search, pass { lemma: true, root: true } in options; for production, pre-build the inverted index with buildInvertedIndex() or loadInvertedIndex() instead of relying on the default O(n) scan",
+    "Range queries like '2:255' or '1:1-7' bypass linguistic search entirely and require sura_id/aya_id fields in the dataset",
+    "Use LRUCache and a pre-built Fuse index (createArabicFuseSearch) together for real-time/keystroke search performance"
+  ]
+}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,5 @@
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ page.title | default: "quran-search-engine Docs" }}</title>
+    <style>
+      body {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 2rem 1rem;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+        line-height: 1.6;
+        color: #24292f;
+      }
+      pre {
+        background: #f6f8fa;
+        padding: 1rem;
+        border-radius: 6px;
+        overflow-x: auto;
+      }
+      code {
+        background: #f6f8fa;
+        padding: 0.2em 0.4em;
+        border-radius: 3px;
+      }
+      table {
+        border-collapse: collapse;
+      }
+      th,
+      td {
+        border: 1px solid #d0d7de;
+        padding: 0.4rem 0.75rem;
+      }
+    </style>
+  </head>
+  <body>
+    {{ content }}
+    <script src="https://context7.com/widget.js" data-library="/adelpro/quran-search-engine"></script>
+  </body>
+</html>


### PR DESCRIPTION
## What I changed

I fixed the Surah Name filter so it works correctly with the combined search results.

## Verification

I tested the change and all 253 tests passed, and the build completed successfully.

## Screenshot
The search was verified using "الرحمن" with the Surah Name filter set to "الفاتحة".

<img width="1557" height="898" alt="fix" src="https://github.com/user-attachments/assets/4fb29276-8817-447f-958a-c3d922c38053" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Search results are now deduplicated across simple, advanced, and semantic search modes, preventing duplicate verses from appearing.
  - Sura, juz, and sura-name filters are now correctly applied to combined search results before boolean search conditions are processed.
  - Corrected an example related to boolean-operator cleanup for more accurate guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->